### PR TITLE
engine: a missing CUDA driver is an error, not a panic

### DIFF
--- a/crates/paddock-engine/src/cuda.rs
+++ b/crates/paddock-engine/src/cuda.rs
@@ -23,6 +23,23 @@ pub struct CudaBackend {
     info: BackendInfo,
 }
 
+/// What a box without the NVIDIA driver is told. The driver is the one thing
+/// paddock needs installed, so name it and the floor.
+pub const NO_DRIVER: &str = "the CUDA driver library (libcuda.so / nvcuda.dll) is not installed; paddock needs the NVIDIA display driver, 580 or newer";
+
+/// Is the CUDA driver library loadable at all? cudarc opens it lazily on the
+/// first driver call and PANICS if it is missing, which is the one outcome the
+/// dynamic-loading choice exists to avoid. Every first touch of the driver in
+/// this crate asks here before it calls, so a machine without the driver gets
+/// an error it can report instead of a crash.
+///
+/// Costs a dlopen, so it belongs at entry points, not on hot paths.
+pub fn driver_present() -> bool {
+    // SAFETY: only tries to open the shared library and drops the handle; it
+    // calls no driver entry point and touches no state of ours.
+    unsafe { cudarc::driver::sys::is_culib_present() }
+}
+
 /// Resolve a `gpu` config selector to a CUDA device ordinal - natively, with
 /// no environment tricks (`CUDA_VISIBLE_DEVICES` is a launcher-era mechanism;
 /// a config-file selection resolves against the driver directly). Accepts a
@@ -46,6 +63,9 @@ pub fn resolve_device(selector: &str) -> Result<usize, CudaError> {
         return Err(CudaError::Driver(format!(
             "gpu selector {selector:?} is neither a device ordinal nor a GPU-<uuid>"
         )));
+    }
+    if !driver_present() {
+        return Err(CudaError::Unavailable(NO_DRIVER.into()));
     }
     cudarc::driver::result::init().map_err(|e| CudaError::Unavailable(e.to_string()))?;
     let count = cudarc::driver::result::device::get_count()
@@ -96,6 +116,9 @@ impl CudaBackend {
     /// Probe device `ordinal`. Failure means "this machine can't do CUDA" -
     /// callers surface that honestly and move on (CPU backend, other devices).
     pub fn probe(ordinal: usize) -> Result<Self, CudaError> {
+        if !driver_present() {
+            return Err(CudaError::Unavailable(NO_DRIVER.into()));
+        }
         let ctx = CudaContext::new(ordinal).map_err(|e| CudaError::Unavailable(e.to_string()))?;
 
         let name = ctx.name().map_err(|e| CudaError::Driver(e.to_string()))?;
@@ -157,6 +180,25 @@ mod tests {
                 tracing::info!("probed: {} ({} bytes)", info.device, info.memory_total);
             }
             Err(e) => tracing::warn!("no CUDA here - skipping ({e})"),
+        }
+    }
+
+    /// Without the driver library every entry point answers `Unavailable`
+    /// naming the driver, and nothing panics. On a box that has the driver
+    /// this only checks the probe agrees with `driver_present`.
+    #[test]
+    fn missing_driver_is_an_error_not_a_panic() {
+        if driver_present() {
+            assert!(CudaBackend::probe(0).is_ok() || resolve_device("0").is_ok());
+            return;
+        }
+        match CudaBackend::probe(0) {
+            Err(CudaError::Unavailable(msg)) => assert!(msg.contains("driver"), "{msg}"),
+            other => panic!("expected Unavailable, got {:?}", other.map(|_| ())),
+        }
+        match resolve_device("GPU-d56cd6c9") {
+            Err(CudaError::Unavailable(msg)) => assert!(msg.contains("driver"), "{msg}"),
+            other => panic!("expected Unavailable, got {other:?}"),
         }
     }
 }

--- a/crates/paddock-engine/src/gpu/mod.rs
+++ b/crates/paddock-engine/src/gpu/mod.rs
@@ -152,6 +152,14 @@ impl GpuExecutor {
         // "cublas64" at all - they could not ask. The only library the engine
         // opens is the CUDA DRIVER, which belongs to the display driver and has
         // exactly one copy on any machine.
+        //
+        // And if that one copy is not there, say so: cudarc panics on its
+        // first call when the library cannot be opened, and a panic here is
+        // the runner dying at startup with a dlopen trace instead of a line
+        // naming the driver.
+        if !crate::cuda::driver_present() {
+            return Err(GpuError::Driver(crate::cuda::NO_DRIVER.into()));
+        }
         let ctx = CudaContext::new(ordinal).map_err(drv)?;
         // A real (non-blocking) stream, not ctx.default_stream(): the null/legacy
         // default stream cannot be captured - cuStreamBeginCapture on it returns

--- a/crates/paddock-engine/src/service.rs
+++ b/crates/paddock-engine/src/service.rs
@@ -6179,6 +6179,13 @@ mod error_class_tests {
             matches!(oom, crate::gpu::GpuError::OutOfMemory),
             "code 2 -> typed OOM"
         );
+        // Rendering any other code goes through cuGetErrorString, which needs
+        // the driver library. The OOM arm above is decided by the code alone,
+        // so that half holds on a box without a GPU; only this half skips.
+        if !crate::cuda::driver_present() {
+            eprintln!("SKIP: no CUDA driver here, the Driver(text) arm needs cuGetErrorString");
+            return;
+        }
         let other = crate::gpu::from_driver(DriverError(CUresult::CUDA_ERROR_INVALID_VALUE));
         assert!(
             matches!(other, crate::gpu::GpuError::Driver(_)),


### PR DESCRIPTION
cudarc loads libcuda.so / nvcuda.dll on the first driver call and panics if
the library is not there. The cuda module promises the opposite, that a box
without CUDA reports the absence as data, and the runner startup, the device
selector and the backend probe all went straight into that panic.

Add driver_present(), a dlopen check on cudarc's is_culib_present, and ask it
at the three first-touch points, GpuExecutor::with_pack, resolve_device and
CudaBackend::probe. Without the driver they now return Unavailable / Driver
naming the driver and the 580 floor.

This also makes the engine's unit tests pass on a machine without a GPU.
probes_local_device_when_present already meant to skip but panicked before
it could, and from_driver_classifies_oom_by_code rendered a non OOM code
through cuGetErrorString. The OOM half of that test still runs everywhere,
only the text half skips. A new test pins the no-driver contract.

cargo test -p paddock-engine --lib on Ubuntu 24.04 without a GPU, 373 passed.

