### PR TITLE
pdfium: add fetch scripts for the prebuilt library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@ packs/*/build/
 packs/pdfium/*
 !packs/pdfium/VERSION
 !packs/pdfium/prebuilt.json
+!packs/pdfium/fetch.sh
+!packs/pdfium/fetch.ps1
 !packs/pdfium/build/
 !packs/pdfium/licenses/
 

--- a/README.md
+++ b/README.md
@@ -173,9 +173,9 @@ Neither `siftx` nor `scriptor` is on crates.io, so cargo fetches them from GitHu
 pinned revision. The first build needs network for that; nothing else does.
 
 ```sh
-# 1. pdfium, a build input linked into paddock-runner
-powershell -File packs/pdfium/build/build-windows.ps1   # Windows
-bash packs/pdfium/build/build-linux.sh                  # Linux, via Docker
+# 1. pdfium, a build input linked into paddock-runner: download our prebuilt
+powershell -File packs/pdfium/fetch.ps1                 # Windows
+bash packs/pdfium/fetch.sh                              # Linux
 
 # 2. the Studio bundle, embedded by rust-embed
 cd studio && npm ci && npm run build && cd ..
@@ -184,12 +184,16 @@ cd studio && npm ci && npm run build && cd ..
 cargo build --release -p paddock-manager -p paddock-runner
 ```
 
-Building pdfium needs depot_tools and takes around 15 minutes; the Windows
-script syncs the Chromium tree into a `pdfium-build` directory beside the
-checkout (`-Root` puts it elsewhere). To skip the build,
-`packs/pdfium/prebuilt.json` carries the download URL and SHA-256 for a build
-of the same pin; put the library at `packs/pdfium/<platform>/` and the build
-script will find it.
+The fetch scripts read `packs/pdfium/prebuilt.json`, download our own build of
+pdfium at the pin in `packs/pdfium/VERSION`, check the SHA-256 and stage the
+library at `packs/pdfium/<platform>/`, where the build script looks for it.
+They are idempotent, so they are safe to run on every build.
+
+To build pdfium from source instead, `packs/pdfium/build/build-windows.ps1`
+(native, needs depot_tools) and `packs/pdfium/build/build-linux.sh` (via
+Docker) stage the same file; both take around 15 minutes. The Windows script
+syncs the Chromium tree into a `pdfium-build` directory beside the checkout
+(`-Root` puts it elsewhere).
 
 The CUDA kernel pack is built separately, on purpose: the Rust build needs
 neither a CUDA toolkit nor a GPU, and the pack is loaded over a stable C ABI at

--- a/crates/paddock-pdfium/build.rs
+++ b/crates/paddock-pdfium/build.rs
@@ -43,12 +43,17 @@ fn main() {
         } else {
             "packs/pdfium/build/build-linux.sh"
         };
+        let fetch = if dir == "win-x64" {
+            "powershell -File packs/pdfium/fetch.ps1"
+        } else {
+            "bash packs/pdfium/fetch.sh"
+        };
         panic!(
             "pdfium is not staged at {}\n\
              \n\
-             build it:                {build}   (needs depot_tools, ~15 min)\n\
-             or download ours:        the URLs and sha256s are in \
-             packs/pdfium/prebuilt.json\n\
+             download ours:           {fetch}   (reads packs/pdfium/prebuilt.json, \
+             checks the sha256)\n\
+             or build it:             {build}   (needs depot_tools, ~15 min)\n\
              \n\
              It is linked INTO this binary, so there is nothing to ship \
              separately - see packs/pdfium/build/ for how it is made.",

--- a/packs/pdfium/fetch.ps1
+++ b/packs/pdfium/fetch.ps1
@@ -1,0 +1,61 @@
+# Stage OUR prebuilt pdfium without building it. Windows twin of fetch.sh.
+#
+#   powershell -File packs\pdfium\fetch.ps1                    # win-x64, the host
+#   powershell -File packs\pdfium\fetch.ps1 -Platform linux-x64
+#
+# Reads packs\pdfium\prebuilt.json, downloads the library for the platform,
+# checks it against the manifest's sha256 and places it where
+# crates\paddock-pdfium\build.rs looks: packs\pdfium\<platform>\. The recipe in
+# build\ is the provenance; this only saves the 15-minute Chromium build.
+#
+# Idempotent: a library that is already staged and matches the manifest is
+# left alone. The download lands in a .part file and is renamed only after the
+# hash matches, so a killed transfer never leaves a wrong-sized library for
+# the linker to find.
+param(
+    [string]$Platform = 'win-x64'
+)
+$ErrorActionPreference = 'Stop'
+# Windows PowerShell 5.1 renders a progress bar per received chunk, which turns
+# a 30 MB download into minutes. Silence it; the transfer is the same.
+$ProgressPreference = 'SilentlyContinue'
+
+$Here = $PSScriptRoot
+$manifest = Get-Content (Join-Path $Here 'prebuilt.json') -Raw | ConvertFrom-Json
+$entry = $manifest.files | Where-Object { $_.platform -eq $Platform }
+if (-not $entry) {
+    throw "no entry for platform '$Platform' in packs\pdfium\prebuilt.json"
+}
+
+# VERSION is the source of truth for the pin; the manifest carries the same
+# string. A mismatch means someone bumped one and not the other.
+$pin = (Get-Content (Join-Path $Here 'VERSION') -Raw).Trim()
+if ($pin -ne $manifest.version) {
+    Write-Warning "packs\pdfium\VERSION is $pin but prebuilt.json is $($manifest.version)"
+}
+
+$destDir = Join-Path $Here $Platform
+New-Item -ItemType Directory -Force -Path $destDir | Out-Null
+$dest = Join-Path $destDir $entry.name
+
+function Sha256Of([string]$Path) {
+    (Get-FileHash -Path $Path -Algorithm SHA256).Hash.ToLowerInvariant()
+}
+
+if ((Test-Path $dest) -and ((Sha256Of $dest) -eq $entry.sha256)) {
+    Write-Host "pdfium already staged: $dest ($($manifest.version))"
+    exit 0
+}
+
+Write-Host "==> pdfium $($manifest.version) for $Platform"
+Write-Host "    $($entry.url)"
+$part = "$dest.part"
+Invoke-WebRequest -Uri $entry.url -OutFile $part -UseBasicParsing
+
+$got = Sha256Of $part
+if ($got -ne $entry.sha256) {
+    Remove-Item -Force $part
+    throw "sha256 mismatch for $($entry.name): expected $($entry.sha256), got $got"
+}
+Move-Item -Force $part $dest
+Write-Host "    staged $dest"

--- a/packs/pdfium/fetch.sh
+++ b/packs/pdfium/fetch.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Stage OUR prebuilt pdfium without building it.
+#
+#   bash packs/pdfium/fetch.sh              # linux-x64, the host
+#   bash packs/pdfium/fetch.sh win-x64      # stage the Windows library instead
+#
+# Reads packs/pdfium/prebuilt.json, downloads the library for the platform,
+# checks it against the manifest's sha256 and places it where
+# crates/paddock-pdfium/build.rs looks: packs/pdfium/<platform>/. This is the
+# shortcut the manifest exists for - the recipe in build/ is the provenance,
+# this only saves the 15-minute Chromium build.
+#
+# Idempotent: a library that is already staged and matches the manifest is
+# left alone, so it is safe to run on every build. The download lands in a
+# .part file and is renamed only after the hash matches, so a killed transfer
+# never leaves a wrong-sized library for the linker to find.
+#
+# Needs curl, and jq or python3 to read the manifest. The Windows twin is
+# fetch.ps1.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MANIFEST="$HERE/prebuilt.json"
+PLATFORM="${1:-linux-x64}"
+
+# The manifest is small and its shape is ours, but parse it properly anyway:
+# a hand-rolled grep would break the day the manifest is re-emitted with
+# different whitespace.
+if command -v jq >/dev/null 2>&1; then
+    read_field() { jq -r --arg p "$PLATFORM" ".files[] | select(.platform == \$p) | .$1" "$MANIFEST"; }
+    read_version() { jq -r '.version' "$MANIFEST"; }
+elif command -v python3 >/dev/null 2>&1; then
+    read_field() {
+        python3 - "$MANIFEST" "$PLATFORM" "$1" <<'PY'
+import json, sys
+manifest, platform, field = sys.argv[1:]
+with open(manifest) as f:
+    files = json.load(f)["files"]
+print(next((e[field] for e in files if e["platform"] == platform), ""))
+PY
+    }
+    read_version() { python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["version"])' "$MANIFEST"; }
+else
+    echo "fetch.sh: need jq or python3 to read $MANIFEST" >&2
+    exit 1
+fi
+
+url="$(read_field url)"
+sha="$(read_field sha256)"
+name="$(read_field name)"
+if [ -z "$url" ] || [ -z "$sha" ] || [ -z "$name" ]; then
+    echo "fetch.sh: no entry for platform '$PLATFORM' in $MANIFEST" >&2
+    exit 1
+fi
+
+# VERSION is the source of truth for the pin; the manifest carries the same
+# string. They move together, so a mismatch means someone bumped one and not
+# the other - say so, but still stage what the manifest describes.
+pin="$(tr -d '[:space:]' < "$HERE/VERSION")"
+version="$(read_version)"
+if [ "$pin" != "$version" ]; then
+    echo "fetch.sh: warning: packs/pdfium/VERSION is $pin but prebuilt.json is $version" >&2
+fi
+
+dest="$HERE/$PLATFORM/$name"
+mkdir -p "$HERE/$PLATFORM"
+
+sha256_of() {
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$1" | cut -d' ' -f1
+    else
+        shasum -a 256 "$1" | cut -d' ' -f1
+    fi
+}
+
+if [ -f "$dest" ] && [ "$(sha256_of "$dest")" = "$sha" ]; then
+    echo "pdfium already staged: $dest ($version)"
+    exit 0
+fi
+
+echo "==> pdfium $version for $PLATFORM"
+echo "    $url"
+curl -fL --progress-bar -o "$dest.part" "$url"
+
+got="$(sha256_of "$dest.part")"
+if [ "$got" != "$sha" ]; then
+    rm -f "$dest.part"
+    echo "fetch.sh: sha256 mismatch for $name" >&2
+    echo "    expected $sha" >&2
+    echo "    got      $got" >&2
+    exit 1
+fi
+mv -f "$dest.part" "$dest"
+echo "    staged $dest"


### PR DESCRIPTION
Building pdfium from source is a 15 minute Chromium build and the README led
with it. Most people just want our prebuilt, and prebuilt.json already has the
URL and sha256, so make that one command.

fetch.sh and fetch.ps1 read the manifest, download the library for the
platform, verify the hash and stage it under packs/pdfium/<platform>/ where
build.rs looks. The download goes to a .part file and is renamed once the hash
matches, so a killed transfer never leaves a bad archive for the linker.
Running it again is a no-op. Both warn if VERSION and prebuilt.json disagree.

build.rs names the fetch script first in its not-staged error, the README
leads with the fetch and keeps the source build as the alternative, and
.gitignore excepts the two scripts under packs/pdfium/*.

Tested on Ubuntu 24.04, fresh download, rerun, without jq, unknown platform,
tampered sha, version mismatch. fetch.ps1 is not yet run on Windows.

