### PR TITLE
Small fixes after the public cut

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Paddock aims at being the fastest inference engine for models that fit on a sing
 GPU, until we support tensor parallelism, meaning splitting model layers across GPUs.
 
 We currently beat llama.cpp, vLLM, SGLang on tested RTX PRO 6000, B200 with models such as
-Qwen 3.8 27B, Qwen 3.6 27B, Gemma 4 31B on F8/Q8_0 and Q4_K_XL and in most cases on NVFP4.
+Qwen 3.8 27B, Qwen 3.6 27B, Gemma 4 31B on FP8/Q8_0 and Q4_K_XL and in most cases on NVFP4.
 We recently added Qwen 3.8 Flash Next and results are promising for lower concurrency but still
 have a bit of work in the higher concurrency tests.
 
@@ -166,6 +166,7 @@ The remaining prerequisites:
 |---|---|
 | Rust, current stable | the toolchain file pins the channel, not a version |
 | Node and npm | builds the Studio bundle embedded into `paddock` |
+| cmake and a C/C++ compiler | the Opus codec is compiled from source at build time, by cmake; on Windows VS2022 covers it |
 | CUDA toolkit 13.x | only for the kernel pack, not for `cargo build` |
 | Windows: VS2022 | build from a `vcvars64` environment; `rc.exe` is also required |
 

--- a/crates/paddock-geo/Cargo.toml
+++ b/crates/paddock-geo/Cargo.toml
@@ -1,9 +1,13 @@
 [package]
 name = "paddock-geo"
+description = "Offline reverse geocoding for photo coordinates: two decimal degrees in, a place name a person recognises out, from an embedded gazetteer so the coordinate never leaves the box."
 version.workspace = true
 edition.workspace = true
 license.workspace = true
 publish = false
+
+[lints]
+workspace = true
 
 [dependencies]
 zstd.workspace = true

--- a/crates/paddock-heif/Cargo.toml
+++ b/crates/paddock-heif/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "paddock-heif"
+description = "HEIF-family images: sniffing and container metadata for AVIF and HEIC, and AVIF pixels through an embedded pure-Rust AV1 decoder. HEIC is named, not decoded."
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/paddock-mcp/Cargo.toml
+++ b/crates/paddock-mcp/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "paddock-mcp"
+description = "MCP (Model Context Protocol) client for Paddock: a thin wrapper over the official rmcp SDK with a lazy, shared connection pool over stdio and Streamable HTTP."
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/paddock-mcp/src/lib.rs
+++ b/crates/paddock-mcp/src/lib.rs
@@ -3,8 +3,7 @@
 //!
 //! Registered servers are inert until a tool is actually needed; `McpManager`
 //! connects on first use and keeps one live client per server, shared across
-//! every request/conversation (this is the "reuse" the API exposes). See
-//!  for the full design.
+//! every request/conversation (this is the "reuse" the API exposes).
 //!
 //! P0 wires the **stdio** (child-process) transport; Streamable HTTP + OAuth
 //! land next behind the same `ServerConfig`/`McpClient` surface.

--- a/packs/pdfium/prebuilt.json
+++ b/packs/pdfium/prebuilt.json
@@ -3,14 +3,14 @@
     "Where to get OUR pdfium build without building it: download the url and",
     "check it against the sha256, then place it at packs/pdfium/<platform>/.",
     "",
-    "These are not a third party's binaries \u00e2\u20ac\u201d they are our own compilation of",
+    "These are not a third party's binaries - they are our own compilation of",
     "PDFium at the pin in VERSION, built by packs/pdfium/build/. The recipe is the",
     "provenance; this file is only the shortcut that saves every developer a",
     "15-minute Chromium build. Bumping the pin means: rebuild both platforms,",
     "re-publish, and replace this file with the manifest that run emits.",
     "",
     "The sha256s are checked on download. They exist to catch a truncated or",
-    "corrupted transfer, not to establish trust \u00e2\u20ac\u201d the bucket is ours."
+    "corrupted transfer, not to establish trust - the bucket is ours."
   ],
   "version": "chromium/8009",
   "files": [


### PR DESCRIPTION
README lists cmake and a C/C++ compiler as prerequisites, the Opus codec is
built from source through cmake and a fresh Ubuntu box fails there before
anything else. FP8 was spelled F8 in the benchmark line.

prebuilt.json had two em dashes that went through a cp1252 round trip and
came out as â€”, plain hyphens now like the rest of the tree.

paddock-geo, paddock-heif and paddock-mcp get the one line description every
other crate has, and paddock-geo picks up [lints] workspace = true, it was
the only crate outside the deny list for unwrap, dbg, todo and unimplemented.
It has none, so nothing changes in the build.

paddock-mcp's module doc pointed at a design doc that did not make it into
the public tree, the dangling sentence is gone. gpu_model/qwen4exp/forward.rs
still names docs/qwen38-flash-next-bringup.md which is not here either, left
as is since that one reads as a real reference worth publishing.

