### PR TITLE
Add CONTRIBUTING.md, issue forms and a PR template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,67 @@
+name: Bug report
+description: Something is wrong, produces bad output, or refuses to run
+labels: [bug]
+body:
+  - type: textarea
+    id: what
+    attributes:
+      label: What happened
+      description: What you did, what you got, and what you expected instead. Paste the exact error text if there is one.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: The command or the Studio steps, the request if it was an API call, and how often it happens.
+      placeholder: |
+        1. paddock ...
+        2. load model ...
+        3. send ...
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Paddock version
+      description: The output of `paddock --version`. It is a build stamp, not just the SemVer, and it tells two builds a week apart from each other.
+      placeholder: paddock 0.1.4 (...)
+    validations:
+      required: true
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - Windows 10/11 x64
+        - Linux x64
+        - Other (say which below)
+    validations:
+      required: true
+  - type: input
+    id: gpu
+    attributes:
+      label: GPU and driver
+      description: The card and the driver version, as the first lines of `nvidia-smi` print them.
+      placeholder: RTX 5090, driver 580.xx
+    validations:
+      required: true
+  - type: input
+    id: model
+    attributes:
+      label: Model
+      description: File name, quantization and where the file came from, if a model is involved.
+      placeholder: Qwen3.8-27B-Q8_0.gguf from the Studio catalog
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs
+      description: The relevant part of `manager.log` or `runner-<port>.log` from the `logs` folder in the data directory (`data` beside the executable for a portable unzip, otherwise `~/paddock`). Also readable in the Studio.
+      render: text
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched the existing issues
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Documentation
+    url: https://truespar.com/paddock/docs/v1/getting-started
+    about: Getting started, configuration and the API surface.
+  - name: GPU access for contributors
+    url: https://github.com/truespar/paddock/blob/main/CONTRIBUTING.md#gpus-for-contributors
+    about: How to get a private RTX 5090, RTX PRO 6000 or B200 for your work on Paddock.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,29 @@
+name: Feature request
+description: Something Paddock should do that it does not
+labels: [enhancement]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: The problem
+      description: What you are trying to do and where Paddock gets in the way. A concrete workload beats an abstract wish.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: What you would like
+      description: The behaviour you want, as an API, a flag, a Studio control or whatever fits.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives you considered
+      description: Other engines that do this, workarounds you use today.
+  - type: checkboxes
+    id: help
+    attributes:
+      label: Contribution
+      options:
+        - label: I am willing to work on this

--- a/.github/ISSUE_TEMPLATE/model_request.yml
+++ b/.github/ISSUE_TEMPLATE/model_request.yml
@@ -1,0 +1,47 @@
+name: Model support
+description: A model or checkpoint that does not load or does not serve correctly
+labels: [model]
+body:
+  - type: input
+    id: model
+    attributes:
+      label: Model
+      description: Name and a link to the checkpoint (Hugging Face or wherever it lives).
+      placeholder: Qwen/Qwen3.8-27B
+    validations:
+      required: true
+  - type: input
+    id: file
+    attributes:
+      label: File and quantization
+      description: GGUF or safetensors, the quantization, and who made the file if it is a conversion.
+      placeholder: Qwen3.8-27B-Q4_K_M.gguf from unsloth
+    validations:
+      required: true
+  - type: textarea
+    id: today
+    attributes:
+      label: What happens today
+      description: The exact error on load, or what is wrong with the output if it loads. Paste the log lines.
+      render: text
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Paddock version
+      description: The output of `paddock --version`.
+    validations:
+      required: true
+  - type: input
+    id: gpu
+    attributes:
+      label: GPU and driver
+      placeholder: RTX PRO 6000, driver 580.xx
+    validations:
+      required: true
+  - type: textarea
+    id: notes
+    attributes:
+      label: Anything else
+      description: Architecture notes, a reference implementation that serves it, whether you can help test.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+## What
+
+<!-- One change per pull request. What changed, and why. -->
+
+## Verified
+
+<!-- What you ran and where. Delete lines that do not apply. -->
+
+- [ ] `cargo fmt --all --check`
+- [ ] `cargo clippy --workspace --all-targets` is clean
+- [ ] `cargo test --workspace`
+- [ ] `cd studio && npm run build && npm test` (if the Studio changed)
+- Built on: <!-- Windows / Linux -->
+- GPU and driver: <!-- if a kernel or the serving path changed, what you measured, on what -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,98 @@
+# Contributing to Paddock
+
+Thanks for looking. Paddock is young and moves fast, so this page is short and
+practical. The README says what the engine is and why; this says how to get a
+change in.
+
+## Where to start
+
+- **Bugs and model support** are the most useful things to bring. Open an
+  issue with the template; `paddock --version`, the GPU and driver, and the
+  model file name are what make a report actionable.
+- **Kernels** live under `packs/cuda/src/`, hand-written CUDA, no Python in
+  the build. `pack.cu`'s include list is the one true order. A kernel change
+  is judged by measurement on a named board, never by reasoning alone; see
+  the GPU offer below if you do not have one.
+- **The engine** is `crates/paddock-engine` (scheduler, paged KV, memory,
+  model families), the serving edge is `crates/paddock-runner`, and the
+  manager plus Studio is `crates/paddock-manager` with the Vue app in
+  `studio/`. Each crate's `Cargo.toml` carries a one-line description.
+
+Not sure where something belongs, or planning something large? Open an issue
+first and say what you intend to do. It is cheap and it saves a rewrite.
+
+## Building
+
+Follow the README's Building section. Two things it is easy to miss:
+
+- On Linux you also need `cmake` and a C/C++ compiler. The Opus codec used
+  for audio is compiled from source at build time, and that build is cmake.
+- The Rust build never needs a CUDA toolkit or a GPU. Only the kernel pack
+  does, and the pack is loaded at runtime over a C ABI.
+
+## Before you open a pull request
+
+Run what CI runs. All of it works on a machine without a GPU.
+
+```sh
+cargo fmt --all --check
+cargo clippy --workspace --all-targets
+cargo test --workspace
+cd studio && npm ci && npm run build && npm test
+```
+
+Clippy must come back clean. The workspace denies `unwrap` in library code,
+along with `dbg!`, `todo!` and `unimplemented!`; a new one is a build error,
+not a warning. `expect` with the invariant named in the message is the
+sanctioned form. Tests may `unwrap` freely.
+
+Tests that need a GPU skip themselves with a notice when no kernel pack or
+device is present. On a box that has both, set `PADDOCK_STRICT_GATES=1` to turn
+every skip into a failure, and `PADDOCK_HEAVY_TESTS=1` to opt into the gates
+that load a whole model. `crates/paddock-engine/tests/common/mod.rs` documents
+how a pack and models are found.
+
+If you touched a kernel or anything on the serving path, say in the pull
+request what you measured, on which GPU and driver, and against what.
+
+## Rules of the tree
+
+- **No silent failures.** An error is reported, not swallowed. Truncation is an
+  error, not a trim. This is the first principle in the README and it is the
+  one reviewers hold hardest.
+- **Line endings are correctness.** `.gitattributes` pins `.sh`, `.py` and
+  Dockerfiles to LF and `.ps1` to CRLF. Do not add a global `text=auto`; the
+  file explains why.
+- **Dependencies stay current**, and the `cudarc` feature pin is
+  load-bearing. `cuda-13000` is what holds the minimum driver at the 580
+  branch; raising it is a release-note decision, never a routine bump. The
+  comment in the root `Cargo.toml` has the reasoning. `siftx` and `scriptor`
+  are git dependencies pinned by revision, so a bump is a deliberate change of
+  the rev.
+- **Windows and Linux, x64, CUDA.** There is no CPU path and no macOS build.
+  Contributions for other backends are a conversation to have in an issue
+  before code.
+
+## Pull requests
+
+- One change per pull request. Small ones merge fast; a mixed one waits for
+  its slowest part.
+- The subject line names the area and what changed, in the style of the
+  history: `scheduler: ...`, `qwen3.8: ...`, `studio: ...`. The body says why,
+  and what you verified.
+- Rebase on `main` rather than merging `main` into your branch.
+
+## GPUs for contributors
+
+Contributors can get a private GPU from us: an RTX 5090, an RTX PRO 6000 or a
+B200, for 24 hours to start and up to 31 days for regular contributors, with
+full access including clocks and Nsight. Capacity is limited and first come,
+first served. Open an issue titled `GPU access: <what you plan to work on>`
+and say roughly how long you need.
+
+## Licence
+
+Paddock is dual-licensed under MIT and Apache-2.0. Unless you state otherwise,
+anything you intentionally submit for inclusion is licensed the same way,
+without additional terms. Third-party code you bring in must be compatible
+and gets its notice in `THIRD-PARTY-NOTICES`.


### PR DESCRIPTION
The repo went public without a word on how to get a change in. This writes
down what the tree already enforces (clippy deny list, line endings, the
cudarc pin, GPU gates that skip without a device), what to run before a PR,
how to ask for a contributor GPU, and the licence terms for contributions.

The issue forms ask for what a report needs to be actionable, paddock
--version, OS, GPU and driver, model and quant, and the runner or manager
log. There is a separate form for model support since that will be the most
common ask. Docs and the GPU offer are contact links.

