### PR TITLE
cuda: fix the pd_dns1_pair template parameter case in deltanet/split.cuh

### DIFF
--- a/packs/cuda/src/deltanet/split.cuh
+++ b/packs/cuda/src/deltanet/split.cuh
@@ -686,7 +686,7 @@ pd_dnc_stage1_v2_kernel(const IT* __restrict__ q, const IT* __restrict__ k,
                 const float v0 = r0 * acc[nt][2u * ep];
                 const float v1 = r1 * acc[nt][2u * ep + 1u];
                 if (warp >= 4u)
-                    *reinterpret_cast<pd_dns1_pair<at>*>(
+                    *reinterpret_cast<pd_dns1_pair<AT>*>(
                         aqk + tb * C * C + i * C + j) =
                         pd_dns1_pair<AT>{(AT)v0, (AT)v1};
                 else {


### PR DESCRIPTION
## What

`packs/cuda/src/deltanet/split.cuh:689` reads `pd_dns1_pair<at>`; the kernel's template parameter is `AT` (line 513). nvcc 13.0.88 stops the pack build on it, so no pack could be built from the public tree here. One character.

## Verified

- [x] `cargo fmt --all --check` (no Rust touched)
- Built on: Windows 11, MSVC 14.44 toolset, `packs/cuda/build.ps1 -Arches 120` with CUDA 13.0
- GPU and driver: RTX 5060 Ti, 581.80 - the resulting pack passes `gpu_delta_net_parity`, `gpu_kquant_parity`, `gpu_moe_parity`, `gpu_matvec_parity` and serves Qwen3.5-9B UD-Q4_K_XL.
