### PR TITLE
engine: MoE expert offload - host-mapped expert planes with a VRAM slot cache

### DIFF
--- a/crates/paddock-engine/src/gpu/host_plane.rs
+++ b/crates/paddock-engine/src/gpu/host_plane.rs
@@ -1,0 +1,192 @@
+//! Device-mapped host mirrors of repacked weight planes - where a MoE
+//! model's routed experts live under `[moe_offload]`.
+//!
+//! The plane sits in page-locked host memory the GPU can address directly
+//! (`cuMemHostAlloc` with `DEVICEMAP`), so the MoE kernels read it over
+//! PCIe on the same `(e*ff + o)` addressing they use for a resident plane:
+//! nothing on the launch side changes and a captured decode graph stays
+//! valid. The mirror is built from the same repack the resident path runs -
+//! staged, repacked on the GPU, copied down, device copy freed - so it is
+//! byte-identical to what the resident plane would hold and greedy parity
+//! against it is a bit-identity check (tests/gpu_kquant_parity.rs).
+//!
+//! Reading every expert over the bus is the floor (~9 tok/s on a PCIe 4.0
+//! x8 35B-A3B); `moe_cache.rs` keeps the hot ones in VRAM on top of this.
+//!
+//! Windows bounds device-mapped pinned memory by the OS's lockable-page
+//! budget (measured on a 64 GB box: 20 GB allocates, 28 GB is refused). A
+//! refusal is a load error naming the size, never a pageable fallback - the
+//! kernels cannot read pageable memory.
+
+use std::mem::ManuallyDrop;
+use std::sync::Arc;
+
+use cudarc::driver::sys as cu;
+use cudarc::driver::{CudaStream, DevicePtr};
+
+use super::{GpuError, GpuExecutor, RepackedKQ};
+use paddock_models::mapped::MappedGguf;
+
+/// One device-mapped pinned host extent, RAII over `cuMemHostAlloc` /
+/// `cuMemFreeHost`.
+pub struct HostMirror {
+    host: *mut core::ffi::c_void,
+    dev: cu::CUdeviceptr,
+    len: usize,
+    /// The stream the plane is read on - drained before the pages go away.
+    stream: Arc<CudaStream>,
+}
+
+// SAFETY: the pointers are owned here, the extent is written once at load
+// (before any kernel reads it) and read-only afterwards, and the engine
+// thread owns every use. Send is needed because the model that owns the
+// plane moves to the engine thread after load.
+unsafe impl Send for HostMirror {}
+unsafe impl Sync for HostMirror {}
+
+impl HostMirror {
+    /// Allocate `len` bytes of device-mapped pinned memory.
+    fn new(stream: Arc<CudaStream>, len: usize, what: &str) -> Result<Self, GpuError> {
+        let mut host: *mut core::ffi::c_void = core::ptr::null_mut();
+        // SAFETY: plain driver call; the out-param is written on success.
+        let rc = unsafe {
+            cu::cuMemHostAlloc(
+                &mut host,
+                len,
+                cu::CU_MEMHOSTALLOC_PORTABLE | cu::CU_MEMHOSTALLOC_DEVICEMAP,
+            )
+        };
+        if rc != cu::CUresult::CUDA_SUCCESS {
+            return Err(GpuError::Driver(format!(
+                "cuMemHostAlloc({} MiB, PORTABLE|DEVICEMAP) for {what}: {rc:?} - the OS refused \
+                 that much page-locked memory; lower the offloaded expert bytes or free RAM",
+                len >> 20
+            )));
+        }
+        let mut dev: cu::CUdeviceptr = 0;
+        // SAFETY: `host` is a live DEVICEMAP allocation from the call above.
+        let rc = unsafe { cu::cuMemHostGetDevicePointer_v2(&mut dev, host, 0) };
+        if rc != cu::CUresult::CUDA_SUCCESS {
+            // SAFETY: freeing what we just allocated, exactly once.
+            let _ = unsafe { cu::cuMemFreeHost(host) };
+            return Err(GpuError::Driver(format!(
+                "cuMemHostGetDevicePointer for {what}: {rc:?}"
+            )));
+        }
+        Ok(Self {
+            host,
+            dev,
+            len,
+            stream,
+        })
+    }
+
+    /// Fill the mirror from a device buffer of exactly `len` bytes.
+    fn fill_from_device(&mut self, src: cu::CUdeviceptr) -> Result<(), GpuError> {
+        self.stream
+            .synchronize()
+            .map_err(|e| GpuError::Driver(format!("host mirror: pre-copy sync: {e}")))?;
+        // SAFETY: `host` spans `len` bytes and nothing reads it yet.
+        let dst = unsafe { core::slice::from_raw_parts_mut(self.host.cast::<u8>(), self.len) };
+        // SAFETY: `src` is a live device buffer of at least `len` bytes.
+        unsafe { cudarc::driver::result::memcpy_dtoh_sync(dst, src) }
+            .map_err(|e| GpuError::Driver(format!("host mirror: dtoh: {e}")))
+    }
+
+    /// A `CudaSlice` view over the mirror's device address. The slice is
+    /// returned under `ManuallyDrop`: its `Drop` would `cuMemFree` a pointer
+    /// that came from `cuMemHostAlloc`. The mirror owns the pages.
+    fn device_view(&self) -> ManuallyDrop<cudarc::driver::CudaSlice<u8>> {
+        // SAFETY: `dev` addresses `len` bytes for as long as `self` lives, and
+        // the ManuallyDrop keeps the slice from ever freeing it.
+        ManuallyDrop::new(unsafe { self.stream.upgrade_device_ptr::<u8>(self.dev, self.len) })
+    }
+
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+}
+
+impl Drop for HostMirror {
+    fn drop(&mut self) {
+        // The plane may still be read by in-flight work on the stream.
+        let _ = self.stream.synchronize();
+        // SAFETY: `host` came from cuMemHostAlloc and is freed exactly once.
+        let _ = unsafe { cu::cuMemFreeHost(self.host) };
+    }
+}
+
+/// A repacked k-quant plane whose bytes live in host-mapped memory. Derefs
+/// to the same `RepackedKQ` the kernels take, so every launch wrapper is
+/// unchanged; the two `CudaSlice`s inside are non-owning views (see
+/// [`HostMirror::device_view`]) and the mirrors own the pages.
+pub struct HostMappedKq {
+    plane: ManuallyDrop<RepackedKQ>,
+    // Declared after `plane` so the views are forgotten before the pages
+    // they point at are released.
+    _data: HostMirror,
+    _scales: HostMirror,
+}
+
+impl HostMappedKq {
+    /// Bytes held in host memory (data + scale streams).
+    pub fn host_bytes(&self) -> u64 {
+        (self._data.len() + self._scales.len()) as u64
+    }
+}
+
+impl std::ops::Deref for HostMappedKq {
+    type Target = RepackedKQ;
+    fn deref(&self) -> &RepackedKQ {
+        &self.plane
+    }
+}
+
+impl GpuExecutor {
+    /// [`GpuExecutor::try_repack_kquant`], landing in a host mirror instead
+    /// of VRAM: repack on the GPU as usual, copy the two streams down, free
+    /// the device copy. `None` when the tensor is not a k-quant type (the
+    /// caller falls through to its Q8 path exactly as it does today).
+    pub fn try_repack_kquant_host_mapped(
+        &self,
+        map: &MappedGguf,
+        name: &str,
+    ) -> Result<Option<HostMappedKq>, GpuError> {
+        let Some(dev) = self.try_repack_kquant(map, name)? else {
+            return Ok(None);
+        };
+        let RepackedKQ {
+            data,
+            scales,
+            dims,
+            ty,
+        } = dev;
+        let mut data_m = HostMirror::new(self.stream.clone(), data.len(), name)?;
+        {
+            let (p, _g) = data.device_ptr(&self.stream);
+            data_m.fill_from_device(p)?;
+        }
+        drop(data);
+        let mut scales_m = HostMirror::new(self.stream.clone(), scales.len(), name)?;
+        {
+            let (p, _g) = scales.device_ptr(&self.stream);
+            scales_m.fill_from_device(p)?;
+        }
+        drop(scales);
+        let plane = RepackedKQ {
+            data: ManuallyDrop::into_inner(data_m.device_view()),
+            scales: ManuallyDrop::into_inner(scales_m.device_view()),
+            dims,
+            ty,
+        };
+        Ok(Some(HostMappedKq {
+            plane: ManuallyDrop::new(plane),
+            _data: data_m,
+            _scales: scales_m,
+        }))
+    }
+}

--- a/crates/paddock-engine/src/gpu/mod.rs
+++ b/crates/paddock-engine/src/gpu/mod.rs
@@ -27,6 +27,12 @@ mod fp4;
 mod fp8;
 mod fused_gemv;
 mod graph;
+mod host_plane;
+pub use host_plane::{HostMappedKq, HostMirror};
+mod moe_cache;
+pub use moe_cache::{
+    ExpertCache, MOE_CACHE_NONE, MoeOffloadCfg, moe_cache_slots_pin, moe_offload, set_moe_offload,
+};
 mod kquant;
 mod types;
 pub use kquant::q40_to_q8_blocks;

--- a/crates/paddock-engine/src/gpu/moe_cache.rs
+++ b/crates/paddock-engine/src/gpu/moe_cache.rs
@@ -1,0 +1,270 @@
+//! MoE expert offload, the VRAM side: a per-layer LRU cache of routed
+//! experts over the host-mapped planes of `host_plane.rs`.
+//!
+//! The cache is three slot planes (gate/up/down) in the same repacked
+//! k-quant layout as a resident plane, holding `slots` experts instead of
+//! `n_expert`, plus the device-side bookkeeping the pack's resolve kernel
+//! updates in place: `slot_of[n_expert]`, `expert_in[slots]`,
+//! `last_use[slots]`, a tick counter. Per launch the engine runs
+//! resolve (ids -> slots, miss jobs) then fill (miss bytes from the mirror
+//! into their slots, PCIe-bound) and hands the unchanged MoE kernels the
+//! slot planes and the remapped ids. All of it captures into the decode
+//! graph; nothing here touches the host after load.
+//!
+//! Sizing: a slot is one expert's gate+up+down bytes (2.0 MB on the 35B-A3B
+//! UD file). Measured on a 4032-token prompt, per-layer LRU hit rates run
+//! 82% at 64 slots, 90% at 96, 94% at 128; enable_batch seats what the KV
+//! plan leaves.
+
+use cudarc::driver::{CudaSlice, DevicePtr};
+
+use super::error::check;
+use super::{GpuError, GpuExecutor, HostMappedKq, RepackedKQ};
+
+/// Sentinel in `slot_of` / `expert_in`: not resident.
+pub const MOE_CACHE_NONE: u32 = u32::MAX;
+
+/// The `[moe_offload]` election, armed once by the runner before any model
+/// loads (families read it at load and at enable_batch) - the same shape as
+/// `kv_tier::pool_tier::set_tier_ram_bytes`. Budgets only: `vram_gb` caps
+/// the slot cache; `None` lets the cache take what the KV plan leaves.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct MoeOffloadCfg {
+    pub enabled: bool,
+    pub vram_bytes: Option<u64>,
+}
+
+static MOE_OFFLOAD: std::sync::OnceLock<MoeOffloadCfg> = std::sync::OnceLock::new();
+
+pub fn set_moe_offload(cfg: MoeOffloadCfg) {
+    let _ = MOE_OFFLOAD.set(cfg);
+}
+
+/// The armed config; `PADDOCK_MOE_HOST=1` is the development switch that
+/// enables it without a config file (tests, bring-up).
+pub fn moe_offload() -> MoeOffloadCfg {
+    let mut c = MOE_OFFLOAD.get().copied().unwrap_or_default();
+    if paddock_models::dev_var_os!("PADDOCK_MOE_HOST").is_some() {
+        c.enabled = true;
+    }
+    c
+}
+
+/// `PADDOCK_MOE_CACHE_SLOTS=<n>`: development pin for the per-layer slot
+/// count, overriding the auto size (the same instrument class as
+/// PADDOCK_KV_POOL_BLOCKS). 0 = no cache (pure zero-copy).
+pub fn moe_cache_slots_pin() -> Option<usize> {
+    paddock_models::dev_var!("PADDOCK_MOE_CACHE_SLOTS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+}
+
+pub struct ExpertCache {
+    pub slots: usize,
+    pub n_expert: usize,
+    /// Rows the per-launch scratch can take (`idx_slot`, `jobs`).
+    pub max_rows: usize,
+    pub gate: RepackedKQ,
+    pub up: RepackedKQ,
+    pub down: RepackedKQ,
+    slot_of: CudaSlice<u32>,
+    expert_in: CudaSlice<u32>,
+    last_use: CudaSlice<u32>,
+    tick: CudaSlice<u32>,
+    idx_slot: CudaSlice<u32>,
+    jobs: CudaSlice<u32>,
+    n_jobs: CudaSlice<u32>,
+    /// `[rows resolved, misses]`, accumulated by every resolve.
+    stats: CudaSlice<u32>,
+    /// Fill descriptors: mirror sources, slot destinations, bytes per expert -
+    /// gate data, gate scales, up data, up scales, down data, down scales.
+    src: [u64; 6],
+    dst: [u64; 6],
+    bytes: [u64; 6],
+}
+
+impl ExpertCache {
+    /// Remapped routing (slot ids) written by the last resolve; the MoE
+    /// kernels take it in place of the expert ids.
+    pub fn idx_slot(&self) -> &CudaSlice<u32> {
+        &self.idx_slot
+    }
+
+    /// `(rows resolved, misses)` since load - a sync + tiny readback, for
+    /// logs and gates, never on the tick.
+    pub fn stats(&self, exec: &GpuExecutor) -> Result<(u64, u64), GpuError> {
+        let v = exec.to_host_u32(&self.stats)?;
+        Ok((v[0] as u64, v[1] as u64))
+    }
+
+    /// VRAM the slot planes hold.
+    pub fn vram_bytes(&self) -> u64 {
+        (self.gate.data.len()
+            + self.gate.scales.len()
+            + self.up.data.len()
+            + self.up.scales.len()
+            + self.down.data.len()
+            + self.down.scales.len()) as u64
+    }
+
+    /// Bytes one slot (one expert across the three planes) costs, from the
+    /// mirrors' per-expert strides.
+    pub fn slot_bytes(gate: &HostMappedKq, up: &HostMappedKq, down: &HostMappedKq) -> u64 {
+        let per = |p: &RepackedKQ| ((p.data.len() + p.scales.len()) / p.dims[2]) as u64;
+        per(gate) + per(up) + per(down)
+    }
+}
+
+impl GpuExecutor {
+    pub fn has_moe_cache(&self) -> bool {
+        self.kernels.moe_cache_resolve.is_some() && self.kernels.moe_cache_fill.is_some()
+    }
+
+    /// Build a `slots`-expert cache over three host-mapped planes of one
+    /// layer. Slot planes are allocated empty; the first ticks fill them.
+    pub fn new_expert_cache(
+        &self,
+        gate: &HostMappedKq,
+        up: &HostMappedKq,
+        down: &HostMappedKq,
+        slots: usize,
+        max_rows: usize,
+    ) -> Result<ExpertCache, GpuError> {
+        let n_expert = gate.dims[2];
+        if slots == 0 || slots > n_expert || up.dims[2] != n_expert || down.dims[2] != n_expert {
+            return Err(GpuError::Driver(format!(
+                "expert cache: {slots} slots over {n_expert} experts (up {}, down {})",
+                up.dims[2], down.dims[2]
+            )));
+        }
+        let mut src = [0u64; 6];
+        let mut dst = [0u64; 6];
+        let mut bytes = [0u64; 6];
+        let mut planes = Vec::with_capacity(3);
+        for (i, p) in [gate, up, down].into_iter().enumerate() {
+            let per_data = p.data.len() / n_expert;
+            let per_scales = p.scales.len() / n_expert;
+            if per_data * n_expert != p.data.len() || per_scales * n_expert != p.scales.len() {
+                return Err(GpuError::Driver(
+                    "expert cache: plane bytes are not a whole number of experts".into(),
+                ));
+            }
+            let data = self.alloc_u8(per_data * slots)?;
+            let scales = self.alloc_u8(per_scales * slots)?;
+            {
+                let (sp, _g1) = p.data.device_ptr(&self.stream);
+                let (ssp, _g2) = p.scales.device_ptr(&self.stream);
+                let (dp, _g3) = data.device_ptr(&self.stream);
+                let (dsp, _g4) = scales.device_ptr(&self.stream);
+                src[2 * i] = sp;
+                src[2 * i + 1] = ssp;
+                dst[2 * i] = dp;
+                dst[2 * i + 1] = dsp;
+            }
+            bytes[2 * i] = per_data as u64;
+            bytes[2 * i + 1] = per_scales as u64;
+            let mut dims = p.dims.clone();
+            dims[2] = slots;
+            planes.push(RepackedKQ {
+                data,
+                scales,
+                dims,
+                ty: p.ty,
+            });
+        }
+        let down_p = planes.pop().expect("three planes pushed");
+        let up_p = planes.pop().expect("three planes pushed");
+        let gate_p = planes.pop().expect("three planes pushed");
+        Ok(ExpertCache {
+            slots,
+            n_expert,
+            max_rows,
+            gate: gate_p,
+            up: up_p,
+            down: down_p,
+            slot_of: self.to_device_u32(&vec![MOE_CACHE_NONE; n_expert])?,
+            expert_in: self.to_device_u32(&vec![MOE_CACHE_NONE; slots])?,
+            last_use: self.to_device_u32(&vec![0u32; slots])?,
+            tick: self.to_device_u32(&[0u32])?,
+            idx_slot: self.to_device_u32(&vec![0u32; max_rows])?,
+            jobs: self.to_device_u32(&vec![0u32; 2 * max_rows])?,
+            n_jobs: self.to_device_u32(&[0u32])?,
+            stats: self.to_device_u32(&[0u32, 0u32])?,
+            src,
+            dst,
+            bytes,
+        })
+    }
+
+    /// Resolve `rows` routed ids (`idx`) against the cache: writes
+    /// `idx_slot`, updates the LRU state, records miss jobs. `rows` must not
+    /// exceed the cache's slots (a tick never evicts what it reads).
+    pub fn moe_cache_resolve(
+        &self,
+        c: &ExpertCache,
+        idx: &CudaSlice<u32>,
+        rows: usize,
+    ) -> Result<(), GpuError> {
+        let f = self
+            .kernels
+            .moe_cache_resolve
+            .ok_or(GpuError::MissingOp("moe_cache_resolve"))?;
+        if rows > c.slots || rows > c.max_rows {
+            return Err(GpuError::Driver(format!(
+                "expert cache resolve: {rows} rows over {} slots / {} scratch rows",
+                c.slots, c.max_rows
+            )));
+        }
+        let (ip, _g0) = idx.device_ptr(&self.stream);
+        let (so, _g1) = c.slot_of.device_ptr(&self.stream);
+        let (ei, _g2) = c.expert_in.device_ptr(&self.stream);
+        let (lu, _g3) = c.last_use.device_ptr(&self.stream);
+        let (tk, _g4) = c.tick.device_ptr(&self.stream);
+        let (is, _g5) = c.idx_slot.device_ptr(&self.stream);
+        let (jb, _g6) = c.jobs.device_ptr(&self.stream);
+        let (nj, _g7) = c.n_jobs.device_ptr(&self.stream);
+        let (st, _g8) = c.stats.device_ptr(&self.stream);
+        // SAFETY: pack ABI v1 contract; the state buffers are written by the
+        // kernel in stream order and read by nothing else off-stream.
+        check(unsafe {
+            f(
+                ip as *const _,
+                rows as u32,
+                c.slots as u32,
+                so as *mut _,
+                ei as *mut _,
+                lu as *mut _,
+                tk as *mut _,
+                is as *mut _,
+                jb as *mut _,
+                nj as *mut _,
+                st as *mut _,
+                self.stream_ptr(),
+            )
+        })
+    }
+
+    /// Copy the last resolve's misses (at most `rows` of them) from the host
+    /// mirror into their slots.
+    pub fn moe_cache_fill(&self, c: &ExpertCache, rows: usize) -> Result<(), GpuError> {
+        let f = self
+            .kernels
+            .moe_cache_fill
+            .ok_or(GpuError::MissingOp("moe_cache_fill"))?;
+        let (jb, _g1) = c.jobs.device_ptr(&self.stream);
+        let (nj, _g2) = c.n_jobs.device_ptr(&self.stream);
+        // SAFETY: pack ABI v1 contract; src/dst/bytes are host arrays the
+        // launcher copies by value before returning.
+        check(unsafe {
+            f(
+                jb as *const _,
+                nj as *const _,
+                rows as u32,
+                c.src.as_ptr() as *const _,
+                c.dst.as_ptr() as *const _,
+                c.bytes.as_ptr() as *const _,
+                self.stream_ptr(),
+            )
+        })
+    }
+}

--- a/crates/paddock-engine/src/gpu_model/qwen35/batch.rs
+++ b/crates/paddock-engine/src/gpu_model/qwen35/batch.rs
@@ -475,6 +475,13 @@ impl GpuQwen35 {
             .plan(grant)
             .map_err(|e| GpuModelError::Config(e.message))?;
         plan.report(&demand, grant);
+        // What the plan leaves after its pools and every listed reserve is
+        // the expert-offload slot cache's budget (sized at the end of this
+        // function, once the pools are allocated).
+        let plan_reserved: u64 = demand.reserves.iter().map(|r| r.bytes).sum::<u64>()
+            + plan.pool_bytes
+            + plan.slot_bytes;
+        let moe_cache_budget = grant.saturating_sub(plan_reserved);
         // An explicit pin is a development instrument: it overrides the plan
         // outright, including past the budget, and says so.
         let pool_block_count = match explicit_pool_pin {
@@ -847,9 +854,18 @@ impl GpuQwen35 {
         // during the prefill phase) and cut TTFT p50 2618 -> 616 ms at
         // equal throughput. The scheduler's overlap_ok conditions still
         // guard per tick; PADDOCK_OVERLAP=0 is the A/B kill switch.
+        // [moe_offload]: the slot cache takes what the plan left, less a
+        // 256 MiB allocator margin - the operator's levers stay max_ctx and
+        // max_batch, exactly as for the KV pool.
+        if !self.moe_cache_active() {
+            self.enable_moe_cache(moe_cache_budget.saturating_sub(256 << 20))?;
+        }
         let overlap_on = paddock_models::dev_var!("PADDOCK_OVERLAP")
             .map(|v| v != "0")
             .unwrap_or(true);
+        // The slot cache is per-layer device state updated in-graph; two
+        // execution lanes replaying against it would race the LRU bookkeeping.
+        let overlap_on = overlap_on && !self.moe_cache_active();
         if self.overlap_exec.is_none() && overlap_on {
             self.overlap_exec = Some(Arc::new(self.exec.fork_stream()?));
             tracing::info!(

--- a/crates/paddock-engine/src/gpu_model/qwen35/load.rs
+++ b/crates/paddock-engine/src/gpu_model/qwen35/load.rs
@@ -70,6 +70,29 @@ fn flatten_for_decode(exec: &GpuExecutor, p: &mut crate::gpu::F8TilePlane) {
     let _ = exec.f8t_flatten(p, in_dim, out_dim);
 }
 
+/// One routed-expert seat of block `i`: the k-quant plane repacked into
+/// VRAM, or under `[moe_offload]` into device-mapped host memory
+/// (gpu/host_plane.rs) for the slot cache to serve. `None` when the tensor
+/// is not k-quant (the caller's Q8 path) or the pack lacks the k-quant MoE
+/// pair (PADDOCK_NO_MOE_KQ=1 restores the old load error for A/B).
+fn kq_expert_seat(
+    exec: &GpuExecutor,
+    map: &MappedGguf,
+    i: usize,
+    name: &str,
+) -> Result<Option<ExpW>, GpuError> {
+    if paddock_models::dev_var_os!("PADDOCK_NO_MOE_KQ").is_some() || !exec.has_kquant_moe() {
+        return Ok(None);
+    }
+    let full = format!("blk.{i}.{name}");
+    Ok(if crate::gpu::moe_offload().enabled {
+        exec.try_repack_kquant_host_mapped(map, &full)?
+            .map(ExpW::KqHost)
+    } else {
+        exec.try_repack_kquant(map, &full)?.map(ExpW::Kq)
+    })
+}
+
 impl GpuQwen35 {
     /// Load a Qwen3.5/3.6 GGUF onto `exec`'s device. Reads the `qwen35.*`
     /// metadata, classifies each block as DeltaNet or full-attn from
@@ -306,7 +329,36 @@ impl GpuQwen35 {
         max_ctx: usize,
         fp8_native_dir: Option<&std::path::Path>,
     ) -> Result<Self, GpuModelError> {
-        exec.vram_load_gate(map.total_len(), "qwen3.5/3.6")
+        // MoE expert offload (PADDOCK_MOE_HOST=1): the k-quant routed-expert
+        // planes land in device-mapped host memory (gpu/host_plane.rs), so
+        // they are not VRAM the gate should charge. The bytes it does not
+        // charge are exactly the tensors the loader will mirror: k-quant
+        // `*_exps` planes of the backbone; Q8 experts and the nextn/MTP
+        // experts stay resident and stay charged.
+        let moe_host = crate::gpu::moe_offload().enabled
+            && paddock_models::dev_var_os!("PADDOCK_NO_MOE_KQ").is_none()
+            && exec.has_kquant_moe();
+        let host_bytes: u64 = if moe_host {
+            map.tensor_infos()
+                .filter(|t| {
+                    t.name.starts_with("blk.")
+                        && t.name.ends_with("_exps.weight")
+                        && crate::gpu::kq_params(t.ggml_type).is_some()
+                })
+                .filter_map(|t| t.byte_size())
+                .sum()
+        } else {
+            0
+        };
+        if host_bytes > 0 {
+            tracing::info!(
+                host_gib = host_bytes as f64 / (1u64 << 30) as f64,
+                "qwen35 MoE expert offload: routed-expert planes will be host-mapped (PADDOCK_MOE_HOST)"
+            );
+        }
+        // The slot cache is sized AFTER the KV plan (enable_batch), from
+        // what the plan leaves - it is not charged here.
+        exec.vram_load_gate(map.total_len().saturating_sub(host_bytes), "qwen3.5/3.6")
             .map_err(GpuModelError::WontFit)?;
         // Single-stream engine: drop cudarc's cross-stream event tracking (pure
         // overhead here, and it blocks CUDA-graph capture). Must precede all allocs.
@@ -897,26 +949,21 @@ impl GpuQwen35 {
                 // per seat. gate and up must agree in residency (one fused
                 // kernel call); down is independent. Q8_0 tensors keep qt8 +
                 // the Q8 sorted family.
-                let moe_kq = paddock_models::dev_var_os!("PADDOCK_NO_MOE_KQ").is_none()
-                    && exec.has_kquant_moe();
-                let kq_exp = |name: &str| -> Result<Option<crate::gpu::RepackedKQ>, GpuError> {
-                    if !moe_kq {
-                        return Ok(None);
-                    }
-                    exec.try_repack_kquant(map, &format!("blk.{i}.{name}"))
-                };
+                // Under [moe_offload] the k-quant seats land in host-mapped
+                // memory instead (gpu/host_plane.rs); Q8 seats stay resident.
+                let kq_exp = |name: &str| kq_expert_seat(&exec, map, i, name);
                 let (gate_exps, up_exps) = match (
                     kq_exp("ffn_gate_exps.weight")?,
                     kq_exp("ffn_up_exps.weight")?,
                 ) {
-                    (Some(g), Some(u)) => (ExpW::Kq(g), ExpW::Kq(u)),
+                    (Some(g), Some(u)) => (g, u),
                     _ => (
                         ExpW::Q8(qt8("ffn_gate_exps.weight")?),
                         ExpW::Q8(qt8("ffn_up_exps.weight")?),
                     ),
                 };
                 let down_exps = match kq_exp("ffn_down_exps.weight")? {
-                    Some(d) => ExpW::Kq(d),
+                    Some(d) => d,
                     None => ExpW::Q8(qt8("ffn_down_exps.weight")?),
                 };
                 Ffn::Moe(MoeFfnWeights {
@@ -932,6 +979,7 @@ impl GpuQwen35 {
                     up_exps_fp4: None,
                     down_exps_fp4: None,
                     moe_zero_bias: None,
+                    cache: None,
                 })
             } else if let Some(nv) = (|| -> Option<Ffn> {
                 // Checkpoint-exact NVFP4 dense FFN (the qwen3.8
@@ -1845,26 +1893,19 @@ impl GpuQwen35 {
                     // backbone (k-quant files ship k-quant nextn experts too;
                     // the spec paths pin sorted_ok=false, so kq seats ride
                     // the token-batched pair there anyway).
-                    let kq_exp = |name: &str| -> Result<Option<crate::gpu::RepackedKQ>, GpuError> {
-                        if paddock_models::dev_var_os!("PADDOCK_NO_MOE_KQ").is_some()
-                            || !exec.has_kquant_moe()
-                        {
-                            return Ok(None);
-                        }
-                        exec.try_repack_kquant(map, &format!("blk.{i}.{name}"))
-                    };
+                    let kq_exp = |name: &str| kq_expert_seat(&exec, map, i, name);
                     let (gate_exps, up_exps) = match (
                         kq_exp("ffn_gate_exps.weight")?,
                         kq_exp("ffn_up_exps.weight")?,
                     ) {
-                        (Some(g), Some(u)) => (ExpW::Kq(g), ExpW::Kq(u)),
+                        (Some(g), Some(u)) => (g, u),
                         _ => (
                             ExpW::Q8(qt8("ffn_gate_exps.weight")?),
                             ExpW::Q8(qt8("ffn_up_exps.weight")?),
                         ),
                     };
                     let down_exps = match kq_exp("ffn_down_exps.weight")? {
-                        Some(d) => ExpW::Kq(d),
+                        Some(d) => d,
                         None => ExpW::Q8(qt8("ffn_down_exps.weight")?),
                     };
                     Ffn::Moe(MoeFfnWeights {
@@ -1880,6 +1921,7 @@ impl GpuQwen35 {
                         up_exps_fp4: None,
                         down_exps_fp4: None,
                         moe_zero_bias: None,
+                        cache: None,
                     })
                 } else {
                     Ffn::Dense {

--- a/crates/paddock-engine/src/gpu_model/qwen35/mod.rs
+++ b/crates/paddock-engine/src/gpu_model/qwen35/mod.rs
@@ -19,7 +19,8 @@
 //! Split into gemma4-shaped submodules.
 
 use crate::gpu::{
-    DeviceTensor, GpuExecutor, KvDtype, QuantTensor, QuantW, RepackedKQ, RepackedMxfp4, RepackedQ8,
+    DeviceTensor, ExpertCache, GpuExecutor, HostMappedKq, KvDtype, QuantTensor, QuantW, RepackedKQ,
+    RepackedMxfp4, RepackedQ8,
 };
 use crate::gpu_model::gpt_oss::GpuModelError;
 use crate::gpu_model::prefix_cache::BLOCK_TOKENS;
@@ -1127,16 +1128,118 @@ fn build_nv4_planes(
 /// their own sorted mma pair (20_kquant_moe, the ks-ring kernels) past the
 /// same pair-count boundary the Q8 seats use - large prefill reads each
 /// touched expert's weights once per pass on both seat kinds.
+impl GpuQwen35 {
+    /// Seat the expert-offload slot cache over every host-mapped MoE layer:
+    /// as many experts per layer as `budget` bytes buy (one slot is one
+    /// expert's gate+up+down bytes in every such layer), capped by
+    /// `[moe_offload] vram_gb`. PADDOCK_MOE_CACHE_SLOTS pins the count
+    /// outright (development instrument, not budget-checked). Returns the
+    /// slots seated; 0 when nothing is host-mapped or the budget buys too few
+    /// to matter, in which case the experts keep serving zero-copy.
+    pub fn enable_moe_cache(&mut self, budget: u64) -> Result<usize, GpuModelError> {
+        fn host_seats(m: &MoeFfnWeights) -> Option<(&HostMappedKq, &HostMappedKq, &HostMappedKq)> {
+            match (&m.gate_exps, &m.up_exps, &m.down_exps) {
+                (ExpW::KqHost(g), ExpW::KqHost(u), ExpW::KqHost(d)) => Some((g, u, d)),
+                _ => None,
+            }
+        }
+        let mut moe: Vec<&mut MoeFfnWeights> = self
+            .layers
+            .iter_mut()
+            .map(|l| &mut l.ffn)
+            .chain(self.mtp.as_mut().map(|m| &mut m.ffn))
+            .filter_map(|ffn| match ffn {
+                Ffn::Moe(m) if m.cache.is_none() => Some(m),
+                _ => None,
+            })
+            .collect();
+        let price: u64 = moe
+            .iter()
+            .filter_map(|m| host_seats(m))
+            .map(|(g, u, d)| ExpertCache::slot_bytes(g, u, d))
+            .sum();
+        if price == 0 || !self.exec.has_moe_cache() {
+            return Ok(0);
+        }
+        let cfg = crate::gpu::moe_offload();
+        let budget = cfg.vram_bytes.map_or(budget, |cap| budget.min(cap));
+        let auto = (budget / price) as usize;
+        let slots = crate::gpu::moe_cache_slots_pin().unwrap_or(auto);
+        let gib = |b: u64| b as f64 / (1u64 << 30) as f64;
+        if slots < 8 {
+            tracing::warn!(
+                slots,
+                budget_gib = gib(budget),
+                "qwen35 MoE expert offload: no room for a slot cache after the KV plan - \
+                 experts serve zero-copy over PCIe (slow); lower max_ctx or max_batch"
+            );
+            return Ok(0);
+        }
+        let mut seated = 0;
+        for m in moe.iter_mut() {
+            if let Some((g, u, d)) = host_seats(m) {
+                let n = slots.min(g.dims[2]);
+                m.cache = Some(self.exec.new_expert_cache(g, u, d, n, 1024)?);
+                seated = n;
+            }
+        }
+        tracing::info!(
+            slots = seated,
+            cache_gib = gib(seated as u64 * price),
+            budget_gib = gib(budget),
+            pinned = crate::gpu::moe_cache_slots_pin().is_some(),
+            "qwen35 MoE expert offload: VRAM slot cache seated (lower max_ctx / max_batch to grow it)"
+        );
+        Ok(seated)
+    }
+
+    /// True when any layer serves its experts through the offload slot cache.
+    pub fn moe_cache_active(&self) -> bool {
+        self.layers
+            .iter()
+            .any(|l| matches!(&l.ffn, Ffn::Moe(m) if m.cache.is_some()))
+    }
+
+    /// Cache counters summed over the layers: `(rows resolved, misses)` since
+    /// load; `None` without a cache. Syncs the stream - for gates and logs.
+    pub fn moe_cache_stats(&self) -> Result<Option<(u64, u64)>, GpuModelError> {
+        let mut acc: Option<(u64, u64)> = None;
+        for l in &self.layers {
+            if let Ffn::Moe(m) = &l.ffn
+                && let Some(c) = &m.cache
+            {
+                let (r, m) = c.stats(&self.exec)?;
+                let a = acc.get_or_insert((0, 0));
+                a.0 += r;
+                a.1 += m;
+            }
+        }
+        Ok(acc)
+    }
+}
+
 enum ExpW {
     Q8(RepackedQ8),
     Kq(RepackedKQ),
+    /// k-quant plane in device-mapped host memory (`[moe_offload]`): the
+    /// kernels read it over PCIe on the same addressing as `Kq`. No VRAM.
+    KqHost(HostMappedKq),
 }
 
 impl ExpW {
     fn q8(&self) -> Option<&RepackedQ8> {
         match self {
             ExpW::Q8(w) => Some(w),
-            ExpW::Kq(_) => None,
+            ExpW::Kq(_) | ExpW::KqHost(_) => None,
+        }
+    }
+    /// The k-quant plane whichever memory it lives in - every launch takes
+    /// the same `RepackedKQ` view.
+    fn kq(&self) -> Option<&RepackedKQ> {
+        match self {
+            ExpW::Q8(_) => None,
+            ExpW::Kq(w) => Some(w),
+            ExpW::KqHost(w) => Some(w),
         }
     }
 }
@@ -1168,6 +1271,10 @@ struct MoeFfnWeights {
     /// mmq kernels, which read a per-(expert,row) bias unconditionally. qwen MoE
     /// has no bias, so every layer points at one buffer via `Arc`.
     moe_zero_bias: Option<Arc<CudaSlice<f32>>>,
+    /// `[moe_offload]`: the VRAM slot cache over host-mapped expert planes,
+    /// seated by `enable_moe_cache`; the token-batched class serves through
+    /// it when the launch's rows fit its slots.
+    cache: Option<ExpertCache>,
 }
 
 /// Dense SwiGLU or routed-expert MoE - per-layer FFN. MoE expert weights stay
@@ -2082,6 +2189,8 @@ impl AuSum {
         match w {
             ExpW::Q8(x) => self.q8(x),
             ExpW::Kq(x) => self.kq(x),
+            // host-mapped: no VRAM, no device allocation to count
+            ExpW::KqHost(_) => {}
         }
     }
     fn fp4(&mut self, w: &RepackedMxfp4) {

--- a/crates/paddock-engine/src/gpu_model/qwen35/ops.rs
+++ b/crates/paddock-engine/src/gpu_model/qwen35/ops.rs
@@ -1146,8 +1146,8 @@ pub(super) fn moe_ffn(
         && exec.compute_capability().0 >= 8
         && paddock_models::dev_var_os!("PADDOCK_NO_QMOE_MMA").is_none();
     let kq_sorted_ok = seats_q8 || {
-        let pair_ok = match (&w.gate_exps, &w.up_exps) {
-            (ExpW::Kq(g), ExpW::Kq(u)) => g.ty == u.ty,
+        let pair_ok = match (w.gate_exps.kq(), w.up_exps.kq()) {
+            (Some(g), Some(u)) => g.ty == u.ty,
             _ => true,
         };
         let all_kq =
@@ -1389,8 +1389,8 @@ pub(super) fn moe_ffn(
                     max_blocks,
                 )?;
             }
-            match (&w.gate_exps, &w.up_exps) {
-                (ExpW::Kq(g), ExpW::Kq(u)) => {
+            match (w.gate_exps.kq(), w.up_exps.kq()) {
+                (Some(g), Some(u)) => {
                     let needs = matches!(g.ty, GgmlType::Q4K | GgmlType::Q5K | GgmlType::Q4_0);
                     if needs {
                         exec.q8_sums_strided(xq, ssums, embd, batch)?;
@@ -1424,8 +1424,8 @@ pub(super) fn moe_ffn(
                     }
                 }
             }
-            match &w.down_exps {
-                ExpW::Kq(d) => {
+            match w.down_exps.kq() {
+                Some(d) => {
                     let needs = matches!(d.ty, GgmlType::Q4K | GgmlType::Q5K | GgmlType::Q4_0);
                     if needs {
                         // sums over the SORTED fq rows (PAD rows hold exact zeros)
@@ -1445,7 +1445,11 @@ pub(super) fn moe_ffn(
                         max_blocks,
                     )?;
                 }
-                ExpW::Q8(d8) => {
+                None => {
+                    let d8 = w
+                        .down_exps
+                        .q8()
+                        .expect("an expert seat is Q8 when not k-quant");
                     if mma {
                         exec.q8_0_moe_down_mma(
                             d8,
@@ -1501,8 +1505,27 @@ pub(super) fn moe_ffn(
         // riding per-16 activation sums; ssums is reused across the two
         // stages (stream-ordered: gate_up consumes the xq sums before the
         // down stage overwrites with fq sums).
-        match (&w.gate_exps, &w.up_exps) {
-            (ExpW::Kq(g), ExpW::Kq(u)) => {
+        // MoE expert offload: when the layer carries a slot cache and this
+        // launch's rows fit it, resolve ids -> slots (LRU, device-side), fill
+        // the misses from the host mirror, and run the pair over the slot
+        // planes with the remapped ids. Otherwise the host-mapped planes
+        // serve directly (zero-copy).
+        let rows = batch * dims.n_active;
+        let cache = w
+            .cache
+            .as_ref()
+            .filter(|c| rows <= c.slots && rows <= c.max_rows);
+        if let Some(c) = cache {
+            exec.moe_cache_resolve(c, idx, rows)?;
+            exec.moe_cache_fill(c, rows)?;
+        }
+        let idx: &CudaSlice<u32> = cache.map_or(idx, |c| c.idx_slot());
+        let seats = match cache {
+            Some(c) => (Some(&c.gate), Some(&c.up), Some(&c.down)),
+            None => (w.gate_exps.kq(), w.up_exps.kq(), w.down_exps.kq()),
+        };
+        match (seats.0, seats.1) {
+            (Some(g), Some(u)) => {
                 let needs = matches!(g.ty, GgmlType::Q4K | GgmlType::Q5K | GgmlType::Q4_0)
                     || matches!(u.ty, GgmlType::Q4K | GgmlType::Q5K | GgmlType::Q4_0);
                 if needs {
@@ -1527,8 +1550,8 @@ pub(super) fn moe_ffn(
             }
         }
         exec.quantize_q8(fused, fq, fs, batch * dims.n_active * dims.moe_ff)?;
-        match &w.down_exps {
-            ExpW::Kq(d) => {
+        match seats.2 {
+            Some(d) => {
                 let needs = matches!(d.ty, GgmlType::Q4K | GgmlType::Q5K | GgmlType::Q4_0);
                 if needs {
                     exec.q8_sums_strided(fq, ssums, dims.moe_ff, batch * dims.n_active)?;
@@ -1545,7 +1568,11 @@ pub(super) fn moe_ffn(
                     batch,
                 )?;
             }
-            ExpW::Q8(d) => {
+            None => {
+                let d = w
+                    .down_exps
+                    .q8()
+                    .expect("an expert seat is Q8 when not k-quant");
                 exec.q8_0_moe_down(d, idx, topk_w, fq, fs, proj, dims.n_active, batch)?;
             }
         }

--- a/crates/paddock-engine/tests/gpu_kquant_parity.rs
+++ b/crates/paddock-engine/tests/gpu_kquant_parity.rs
@@ -2534,3 +2534,123 @@ fn q40_transcode_is_exact() {
         }
     }
 }
+
+/// MoE expert offload, phase A: the same expert block served from a
+/// device-mapped host mirror must produce BIT-identical gate_up and down
+/// outputs to the VRAM-resident plane. Same repack, same kernels, same
+/// addressing - only the memory the bytes sit in differs.
+#[test]
+fn kq_moe_pair_host_mapped_bitmatches_resident() {
+    let Some(model) = common::model("QWEN36_MOE_UD_GGUF", common::QWEN36_35B_A3B_UD_Q4) else {
+        return;
+    };
+    let Some(exec) = common::gpu() else {
+        return;
+    };
+    if !exec.has_kquant_moe() {
+        eprintln!("pack lacks the k-quant MoE pair - skipping");
+        return;
+    }
+    let map = MappedGguf::open(&model).expect("open gguf");
+    let names = [
+        "blk.0.ffn_gate_exps.weight".to_string(),
+        "blk.0.ffn_up_exps.weight".to_string(),
+        "blk.0.ffn_down_exps.weight".to_string(),
+    ];
+    let res: Vec<_> = names
+        .iter()
+        .map(|n| exec.repack_kquant(&map, n).expect("resident repack"))
+        .collect();
+    let host: Vec<_> = names
+        .iter()
+        .map(|n| {
+            exec.try_repack_kquant_host_mapped(&map, n)
+                .expect("host-mapped repack")
+                .expect("k-quant expert tensor")
+        })
+        .collect();
+    let (embd, ff, ne) = (res[0].dims[0], res[0].dims[1], res[0].dims[2]);
+    eprintln!(
+        "host-mapped expert block [{embd}x{ff}x{ne}] {:.1} MB in host memory",
+        host.iter().map(|h| h.host_bytes()).sum::<u64>() as f64 / 1e6
+    );
+
+    let batch = 3usize;
+    let n_active = 8usize;
+    let idx_h: Vec<u32> = (0..batch * n_active)
+        .map(|i| ((i as u32).wrapping_mul(2654435761) >> 7) % ne as u32)
+        .collect();
+    let topk_h: Vec<f32> = (0..batch * n_active)
+        .map(|i| 1.0 / (1.0 + (i % n_active) as f32))
+        .collect();
+    let d_idx = exec.to_device_u32(&idx_h).expect("idx");
+    let d_topk = exec.to_device(&topk_h).expect("topk");
+    let x = deterministic_input(batch * embd, 11);
+    let d_x = exec.to_device(&x).expect("x");
+    let mut d_xq = exec.alloc_i8(batch * embd).expect("xq");
+    let mut d_xs = exec.alloc(batch * embd / 32).expect("xs");
+    exec.quantize_q8(&d_x, &mut d_xq, &mut d_xs, batch * embd)
+        .expect("quantize");
+    let mut d_sums = exec
+        .alloc(batch * embd.max(n_active * ff) / 16)
+        .expect("sums");
+    exec.q8_sums_strided(&d_xq, &mut d_sums, embd, batch)
+        .expect("sums");
+
+    let run = |gate: &paddock_engine::gpu::RepackedKQ,
+               up: &paddock_engine::gpu::RepackedKQ,
+               down: &paddock_engine::gpu::RepackedKQ|
+     -> (Vec<f32>, Vec<f32>) {
+        let mut d_fused = exec.alloc(batch * n_active * ff).expect("fused");
+        exec.kquant_moe_gate_up(
+            gate,
+            up,
+            &d_idx,
+            &d_xq,
+            &d_xs,
+            Some(&d_sums),
+            &mut d_fused,
+            n_active,
+            batch,
+        )
+        .expect("gate_up");
+        let fused = exec.to_host(&d_fused).expect("fused host");
+        let mut d_fq = exec.alloc_i8(batch * n_active * ff).expect("fq");
+        let mut d_fs = exec.alloc(batch * n_active * ff / 32).expect("fs");
+        exec.quantize_q8(&d_fused, &mut d_fq, &mut d_fs, batch * n_active * ff)
+            .expect("fq quant");
+        let mut d_fsums = exec.alloc(batch * n_active * ff / 16).expect("fsums");
+        exec.q8_sums_strided(&d_fq, &mut d_fsums, ff, batch * n_active)
+            .expect("fsums");
+        let mut d_out = exec.alloc(batch * embd).expect("out");
+        exec.kquant_moe_down(
+            down,
+            &d_idx,
+            &d_topk,
+            &d_fq,
+            &d_fs,
+            Some(&d_fsums),
+            &mut d_out,
+            n_active,
+            batch,
+        )
+        .expect("down");
+        (fused, exec.to_host(&d_out).expect("out host"))
+    };
+    let (fused_r, out_r) = run(&res[0], &res[1], &res[2]);
+    let (fused_h, out_h) = run(&host[0], &host[1], &host[2]);
+    let same = |a: &[f32], b: &[f32]| a.iter().zip(b).all(|(x, y)| x.to_bits() == y.to_bits());
+    eprintln!(
+        "host-mapped vs resident: gate_up bitwise={} down bitwise={}",
+        same(&fused_r, &fused_h),
+        same(&out_r, &out_h)
+    );
+    assert!(
+        same(&fused_r, &fused_h),
+        "gate_up differs between host-mapped and resident planes"
+    );
+    assert!(
+        same(&out_r, &out_h),
+        "down differs between host-mapped and resident planes"
+    );
+}

--- a/crates/paddock-engine/tests/gpu_qwen36_moe_host.rs
+++ b/crates/paddock-engine/tests/gpu_qwen36_moe_host.rs
@@ -1,0 +1,64 @@
+//! MoE expert offload (PADDOCK_MOE_HOST) on the serial path: load the 35B-A3B
+//! UD file with its routed experts host-mapped and greedy-generate. The
+//! all-resident twin does not fit a 16 GB card, so this gate checks the path
+//! runs and prints tokens + tok/s; bit-parity against resident is the
+//! kernel-level gate in gpu_kquant_parity.
+mod common;
+
+use std::time::Instant;
+
+use paddock_engine::gpu_model::qwen35::GpuQwen35;
+use paddock_models::mapped::MappedGguf;
+
+#[test]
+fn moe_host_mapped_generates() {
+    if !common::heavy() {
+        return;
+    }
+    let Some(path) = common::model("QWEN36_MOE_UD_GGUF", common::QWEN36_35B_A3B_UD_Q4) else {
+        return;
+    };
+    let Some(exec) = common::gpu_arc() else {
+        return;
+    };
+    // SAFETY: single-threaded test binary, set before any reader.
+    unsafe { std::env::set_var("PADDOCK_MOE_HOST", "1") };
+    let map = MappedGguf::open(&path).expect("open gguf");
+    let t0 = Instant::now();
+    let mut m = GpuQwen35::load(exec, &map, 2048).expect("load moe host-mapped");
+    // PADDOCK_MOE_CACHE_SLOTS pins the count; default 64 per layer (5 GB)
+    if paddock_engine::gpu::moe_cache_slots_pin().is_none() {
+        // SAFETY: single-threaded test binary, set before any reader.
+        unsafe { std::env::set_var("PADDOCK_MOE_CACHE_SLOTS", "64") };
+    }
+    let seated = m.enable_moe_cache(u64::MAX).expect("seat expert cache");
+    eprintln!(
+        "load {:.1}s, cache {seated} slots/layer",
+        t0.elapsed().as_secs_f64()
+    );
+    let prompt: Vec<u32> = vec![760, 6511, 314, 9338, 369];
+    let n = 32usize;
+    let t1 = Instant::now();
+    let out = m.generate_greedy(&prompt, n, None).expect("generate");
+    let s = t1.elapsed().as_secs_f64();
+    eprintln!("tokens {out:?}");
+    eprintln!(
+        "{n} tokens in {s:.2}s = {:.2} tok/s (incl. prefill + graph capture)",
+        n as f64 / s
+    );
+    let t2 = Instant::now();
+    let out2 = m.generate_greedy(&prompt, n, None).expect("generate 2");
+    let s2 = t2.elapsed().as_secs_f64();
+    eprintln!(
+        "rerun: {:.2} tok/s, deterministic={}",
+        n as f64 / s2,
+        out == out2
+    );
+    if let Some((rows, misses)) = m.moe_cache_stats().expect("cache stats") {
+        eprintln!(
+            "expert cache: {rows} rows resolved, {misses} misses, hit rate {:.1}%",
+            100.0 * (1.0 - misses as f64 / rows.max(1) as f64)
+        );
+    }
+    assert_eq!(out, out2, "greedy must be deterministic run-to-run");
+}

--- a/crates/paddock-kernels/src/abi.rs
+++ b/crates/paddock-kernels/src/abi.rs
@@ -5945,7 +5945,45 @@ pub struct KernelTableV1 {
     pub swiglu_fused_nvf4_il: Option<SwigluFusedNvf4Fn>,
     /// Slot 536: pd_swiglu_quant_nvf4_from_parts over interleaved partials.
     pub swiglu_quant_nvf4_from_parts_il: Option<SwigluQuantNvf4FromPartsFn>,
+    /// Slot 537: MoE expert-offload cache resolve - routed expert ids to
+    /// VRAM slot ids with device-side LRU bookkeeping; writes the miss jobs.
+    /// (idx, rows, n_slots, slot_of[n_expert], expert_in[S], last_use[S],
+    /// tick, idx_slot[rows], jobs[2*rows], n_jobs, stats[2] (rows, misses
+    /// accumulators), stream); rows <= n_slots.
+    pub moe_cache_resolve: Option<MoeCacheResolveFn>,
+    /// Slot 538: MoE expert-offload cache fill - copies the resolve's miss
+    /// jobs from the host-mapped mirror into their slots over six streams
+    /// (gate/up/down x data/scales). (jobs, n_jobs (device), max_jobs,
+    /// src[6], dst[6], bytes[6] (HOST u64 arrays), stream).
+    pub moe_cache_fill: Option<MoeCacheFillFn>,
 }
+
+/// MoE expert-offload cache resolve (see `KernelTableV1::moe_cache_resolve`).
+pub type MoeCacheResolveFn = unsafe extern "C" fn(
+    *const core::ffi::c_void,
+    u32,
+    u32,
+    *mut core::ffi::c_void,
+    *mut core::ffi::c_void,
+    *mut core::ffi::c_void,
+    *mut core::ffi::c_void,
+    *mut core::ffi::c_void,
+    *mut core::ffi::c_void,
+    *mut core::ffi::c_void,
+    *mut core::ffi::c_void,
+    *mut core::ffi::c_void,
+) -> i32;
+
+/// MoE expert-offload cache fill (see `KernelTableV1::moe_cache_fill`).
+pub type MoeCacheFillFn = unsafe extern "C" fn(
+    *const core::ffi::c_void,
+    *const core::ffi::c_void,
+    u32,
+    *const core::ffi::c_void,
+    *const core::ffi::c_void,
+    *const core::ffi::c_void,
+    *mut core::ffi::c_void,
+) -> i32;
 
 /// Slot 533: see the KernelTableV1 field doc.
 pub type Nvf4GemmF4tSwqFn = unsafe extern "C" fn(
@@ -6295,7 +6333,7 @@ pub type AddRmsnormQ8XnFn = unsafe extern "C" fn(
 /// the copy to the smaller of declared and expected, so an old pack against a
 /// new engine (or the reverse) reads missing entries as None rather than a
 /// shifted slot.
-pub const KERNEL_TABLE_SLOTS: usize = 537;
+pub const KERNEL_TABLE_SLOTS: usize = 539;
 
 const _: () = assert!(
     core::mem::size_of::<KernelTableV1>() == 8 + KERNEL_TABLE_SLOTS * 8,
@@ -9378,6 +9416,8 @@ mod tests {
         // 250/251: bf16_to_f8r + f8r_gemm_mma_ks (per-row scale-free stream).
         // 252: swiglu_fused_e4m3 (decode step-glue fusion).
         // 253: add_rmsnorm_e4m3_xn (decode norm+quant fuse).
+        // 537/538: moe_cache_resolve + moe_cache_fill (MoE expert offload,
+        // device-managed LRU slot cache over host-mapped expert planes).
         // 254..256: the tile-linear f8 lane (f8w_repack_lin / f8_gemm_lin /
         // f8_gemm_lin_kt - access-pattern fix).
         // 257: add_rmsnorm_e4m3_xn_b16 (prefill glue fusion).

--- a/crates/paddock-runner/src/config.rs
+++ b/crates/paddock-runner/src/config.rs
@@ -23,6 +23,20 @@ pub struct KvOffload {
     pub nvme_path: Option<PathBuf>,
 }
 
+/// `[moe_offload]` - MoE expert offload: the routed-expert planes of a MoE
+/// model live in page-locked host RAM the GPU reads over PCIe, with a VRAM
+/// slot cache of the hot experts sized from what the KV plan leaves. Lets a
+/// model whose experts do not fit the card serve at cache-hit speed; only
+/// k-quant expert seats offload today. `vram_gb` caps the slot cache (unset =
+/// auto: everything the plan leaves). Lower `max_ctx` / `max_batch` to give
+/// the cache more room.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct MoeOffload {
+    pub enabled: bool,
+    pub vram_gb: Option<f64>,
+}
+
 #[derive(Debug, Clone, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct Config {
@@ -90,6 +104,8 @@ pub struct Config {
     pub vram_budget: Option<u64>,
     /// See [`KvOffload`].
     pub kv_offload: KvOffload,
+    /// See [`MoeOffload`].
+    pub moe_offload: MoeOffload,
     /// Default max output tokens per reply when a request doesn't specify.
     pub max_tokens: Option<usize>,
     /// API key for Bearer auth. Empty + loopback bind = no auth; empty +
@@ -299,6 +315,7 @@ impl Default for Config {
             fp8_native: None,
             vram_budget: None,
             kv_offload: KvOffload::default(),
+            moe_offload: MoeOffload::default(),
             max_tokens: None,
             api_key: None,
             no_auth: false,

--- a/crates/paddock-runner/src/lib.rs
+++ b/crates/paddock-runner/src/lib.rs
@@ -231,6 +231,27 @@ pub async fn run(
             .clone()
             .map(|(p, gb)| (p, (gb * (1u64 << 30) as f64) as u64)),
     );
+    // [moe_offload]: armed the same way, read by the MoE families at load
+    // (host-map the expert planes) and at enable_batch (seat the slot cache).
+    let mo = &cfg.moe_offload;
+    if !mo.enabled && mo.vram_gb.is_some() {
+        tracing::warn!(
+            "[moe_offload] vram_gb is set but enabled = false - experts stay VRAM-resident \
+             and a model that does not fit will be refused. Set enabled = true."
+        );
+    }
+    paddock_engine::gpu::set_moe_offload(paddock_engine::gpu::MoeOffloadCfg {
+        enabled: mo.enabled,
+        vram_bytes: mo
+            .vram_gb
+            .map(|g| (g.max(0.0) * (1u64 << 30) as f64) as u64),
+    });
+    if mo.enabled {
+        tracing::info!(
+            vram_gb = mo.vram_gb,
+            "[moe_offload] MoE expert offload armed (slot cache auto-sized from the KV plan's leftover unless vram_gb caps it)"
+        );
+    }
     if ram_armed {
         tracing::info!(
             ram_gb = kv.ram_gb,

--- a/packs/cuda/pack.cu
+++ b/packs/cuda/pack.cu
@@ -52,6 +52,7 @@
 #include "src/asr/whisper.cuh"      // whisper decode lane (flash-decoding attn + fused decode epilogues)
 #include "src/asr/granite_speech.cuh"  // granite-speech conformer tower (macaron FFN, GLU, centered dwconv, Shaw-RPE attention)
 #include "src/moe/kquant.cuh"       // k-quant MoE expert seats (needs the two kquant segments)
+#include "src/moe/offload.cuh"      // MoE expert offload: device-managed LRU slot cache over host-mapped expert planes (needs kquant.cuh layouts; plain CUDA)
 #include "src/dflash.cuh"        // DFlash2 drafter grouped dynamic conv (abi.cuh helpers only)
 #include "src/tier/xfer.cuh"     // KV tier extent gather/scatter (kv-offload 1a.2; abi.cuh helpers only)
 #include "src/exports.cuh"

--- a/packs/cuda/src/abi.cuh
+++ b/packs/cuda/src/abi.cuh
@@ -2698,6 +2698,19 @@ struct KernelTableV1 {
     int (*swiglu_fused_nvf4_il)(const void*, void*, void*, uint32_t, uint32_t, void*);
     int (*swiglu_quant_nvf4_from_parts_il)(const void*, const void*, void*, void*,
                                            uint32_t, uint32_t, float, uint32_t, void*);
+    // 537: MoE expert-offload cache resolve - expert ids -> slot ids with
+    // device-side LRU bookkeeping, emits the miss jobs. (idx, rows, n_slots,
+    // slot_of[n_expert], expert_in[S], last_use[S], tick, idx_slot[rows],
+    // jobs[2*rows], n_jobs, stats[2] (rows, misses accumulators), stream);
+    // rows <= n_slots.
+    int (*moe_cache_resolve)(const void*, uint32_t, uint32_t, void*, void*, void*,
+                             void*, void*, void*, void*, void*, void*);
+    // 538: MoE expert-offload cache fill - copy the resolve's miss jobs from
+    // the host-mapped mirror into their slots, six streams (gate/up/down x
+    // data/scales). (jobs, n_jobs (device), max_jobs, src[6], dst[6],
+    // bytes[6] (host u64 arrays), stream).
+    int (*moe_cache_fill)(const void*, const void*, uint32_t, const void*,
+                          const void*, const void*, void*);
 };
 
 } // extern "C"

--- a/packs/cuda/src/deltanet/split.cuh
+++ b/packs/cuda/src/deltanet/split.cuh
@@ -686,7 +686,7 @@ pd_dnc_stage1_v2_kernel(const IT* __restrict__ q, const IT* __restrict__ k,
                 const float v0 = r0 * acc[nt][2u * ep];
                 const float v1 = r1 * acc[nt][2u * ep + 1u];
                 if (warp >= 4u)
-                    *reinterpret_cast<pd_dns1_pair<at>*>(
+                    *reinterpret_cast<pd_dns1_pair<AT>*>(
                         aqk + tb * C * C + i * C + j) =
                         pd_dns1_pair<AT>{(AT)v0, (AT)v1};
                 else {

--- a/packs/cuda/src/exports.cuh
+++ b/packs/cuda/src/exports.cuh
@@ -1466,6 +1466,8 @@ static const KernelTableV1 PD_KERNELS = {
     pd_swiglu_fused_il,
     pd_swiglu_fused_nvf4_il,
     pd_swiglu_quant_nvf4_from_parts_il,
+    pd_moe_cache_resolve,
+    pd_moe_cache_fill,
 };
 
 PD_EXPORT const PackInfo* paddock_pack_info(void) {

--- a/packs/cuda/src/moe/offload.cuh
+++ b/packs/cuda/src/moe/offload.cuh
@@ -1,0 +1,140 @@
+// moe/offload.cuh - MoE expert offload: a device-managed LRU cache of routed
+// experts in VRAM, fed from a host-mapped mirror of the full expert planes.
+//
+// Everything here runs INSIDE the decode/prefill graphs: routing -> resolve
+// (expert id -> cache slot, LRU victim on a miss) -> fill (copy the missing
+// experts' repacked bytes from the pinned host mirror into their slots) ->
+// the unchanged MoE kernels over the slot planes with the remapped ids. No
+// host round-trip, no sync, and the cache state lives in device memory, so a
+// captured graph keeps making correct decisions on every replay.
+//
+// Slot planes carry the same repacked k-quant layout as a resident plane
+// (moe/kquant.cuh addressing `(slot*ff + o) * n_super * bytes`), which is
+// what lets the consumer kernels stay untouched: a slot IS an expert index
+// into a plane that happens to hold S experts instead of n_expert.
+//
+// resolve: one block, thread 0 walks the rows in order. Rows are at most a
+// few hundred on the token-batched class this serves (decode: B x top-k), so
+// a serial walk is microseconds and keeps the LRU bookkeeping trivially
+// race-free. A row whose expert is resident takes its slot; a miss takes the
+// least-recently-used slot that no row of THIS tick pinned (so a tick never
+// evicts what it is about to read - the caller guarantees rows <= S). Empty
+// slots have last_use 0 and are taken first.
+//
+// fill: grid (chunks, 6 streams, jobs). Every block re-reads the job count
+// the resolve wrote, so the launch is shaped for the maximum and idles the
+// blocks past the real count - graph-stable grids, live job counts.
+// The six streams are gate/up/down x data/scales; sizes come from the
+// planes, the kernel only knows byte ranges. uint4 copies, coalesced: this
+// is the PCIe-bound path; measured at 12.6 GB/s on a PCIe 4.0 x8 link, the
+// link's practical ceiling for this access pattern.
+
+#define PD_MOE_CACHE_NONE 0xFFFFFFFFu
+
+__global__ void pd_moe_cache_resolve_kernel(
+    const unsigned int* __restrict__ idx, uint32_t rows, uint32_t n_slots,
+    unsigned int* __restrict__ slot_of, unsigned int* __restrict__ expert_in,
+    unsigned int* __restrict__ last_use, unsigned int* __restrict__ tick,
+    unsigned int* __restrict__ idx_slot, unsigned int* __restrict__ jobs,
+    unsigned int* __restrict__ n_jobs, unsigned int* __restrict__ stats) {
+    if (threadIdx.x != 0) return;
+    const unsigned int t = *tick + 1u;
+    *tick = t;
+    unsigned int nj = 0;
+    for (uint32_t r = 0; r < rows; ++r) {
+        const unsigned int e = idx[r];
+        unsigned int s = slot_of[e];
+        if (s != PD_MOE_CACHE_NONE) {
+            idx_slot[r] = s;
+            last_use[s] = t;
+            continue;
+        }
+        // miss: LRU victim among slots not pinned by this tick
+        unsigned int victim = PD_MOE_CACHE_NONE, best = 0xFFFFFFFFu;
+        for (uint32_t c = 0; c < n_slots; ++c) {
+            const unsigned int lu = last_use[c];
+            if (lu != t && lu < best) { best = lu; victim = c; }
+        }
+        if (victim == PD_MOE_CACHE_NONE) {
+            // cannot happen when rows <= n_slots (caller's contract); make the
+            // failure loud rather than silent: point the row at slot 0 and
+            // flag it in the job count's high bit
+            idx_slot[r] = 0;
+            nj |= 0x80000000u;
+            continue;
+        }
+        const unsigned int old = expert_in[victim];
+        if (old != PD_MOE_CACHE_NONE) slot_of[old] = PD_MOE_CACHE_NONE;
+        expert_in[victim] = e;
+        slot_of[e] = victim;
+        last_use[victim] = t;
+        idx_slot[r] = victim;
+        jobs[2u * (nj & 0x7FFFFFFFu)] = victim;
+        jobs[2u * (nj & 0x7FFFFFFFu) + 1u] = e;
+        ++nj;
+    }
+    *n_jobs = nj;
+    // running counters for the hit-rate readout: [0] rows resolved, [1] misses
+    stats[0] += rows;
+    stats[1] += nj & 0x7FFFFFFFu;
+}
+
+struct PdMoeFillDesc {
+    unsigned long long src[6];    // host-mirror device pointers, one per stream
+    unsigned long long dst[6];    // slot-plane base pointers
+    unsigned long long bytes[6];  // bytes per expert per stream (multiple of 16)
+};
+
+__global__ void __launch_bounds__(256) pd_moe_cache_fill_kernel(
+    const unsigned int* __restrict__ jobs, const unsigned int* __restrict__ n_jobs,
+    const __grid_constant__ PdMoeFillDesc d) {
+    const uint32_t j = blockIdx.z;
+    if (j >= (*n_jobs & 0x7FFFFFFFu)) return;
+    const uint32_t k = blockIdx.y;
+    const unsigned int slot = jobs[2u * j], e = jobs[2u * j + 1u];
+    const unsigned long long nb = d.bytes[k];
+    const uint4* __restrict__ src = (const uint4*)(d.src[k] + (unsigned long long)e * nb);
+    uint4* __restrict__ dst = (uint4*)(d.dst[k] + (unsigned long long)slot * nb);
+    const uint32_t n16 = (uint32_t)(nb >> 4);
+    for (uint32_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n16; i += gridDim.x * blockDim.x)
+        dst[i] = src[i];
+}
+
+PD_EXPORT
+int pd_moe_cache_resolve(const void* idx, uint32_t rows, uint32_t n_slots,
+                         void* slot_of, void* expert_in, void* last_use,
+                         void* tick, void* idx_slot, void* jobs, void* n_jobs,
+                         void* stats, void* stream) {
+    if (rows == 0 || n_slots == 0) return cudaErrorInvalidValue;
+    if (rows > n_slots) return cudaErrorInvalidValue;
+    pd_moe_cache_resolve_kernel<<<1, 32, 0, (cudaStream_t)stream>>>(
+        (const unsigned int*)idx, rows, n_slots, (unsigned int*)slot_of,
+        (unsigned int*)expert_in, (unsigned int*)last_use, (unsigned int*)tick,
+        (unsigned int*)idx_slot, (unsigned int*)jobs, (unsigned int*)n_jobs,
+        (unsigned int*)stats);
+    return pd_launch_status();
+}
+
+// src/dst/bytes: HOST arrays of 6 u64 each, copied into the launch by value.
+PD_EXPORT
+int pd_moe_cache_fill(const void* jobs, const void* n_jobs, uint32_t max_jobs,
+                      const void* src, const void* dst, const void* bytes,
+                      void* stream) {
+    if (max_jobs == 0) return 0;
+    if (max_jobs > 1024u) return cudaErrorInvalidValue;
+    PdMoeFillDesc d;
+    for (int k = 0; k < 6; ++k) {
+        d.src[k] = ((const unsigned long long*)src)[k];
+        d.dst[k] = ((const unsigned long long*)dst)[k];
+        d.bytes[k] = ((const unsigned long long*)bytes)[k];
+        if (d.bytes[k] & 15ull) return cudaErrorInvalidValue;
+    }
+    // 16 chunks x 256 threads x 16 B = 64 KB per pass over a ~0.5 MB stream:
+    // enough blocks in flight to keep the link busy (measured flat from 4 to
+    // 64 chunks), small enough that a 1-job decode fill is not a 1000-block
+    // launch
+    dim3 grid(16u, 6u, max_jobs);
+    pd_moe_cache_fill_kernel<<<grid, 256, 0, (cudaStream_t)stream>>>(
+        (const unsigned int*)jobs, (const unsigned int*)n_jobs, d);
+    return pd_launch_status();
+}

--- a/paddock.example.toml
+++ b/paddock.example.toml
@@ -119,3 +119,18 @@
 # ram_gb = 24.0
 # nvme_gb = 200.0
 # nvme_path = "D:/paddock-cache"
+
+# --- MoE expert offload
+
+# Serves a mixture-of-experts model whose routed experts do not fit the card:
+# the expert planes live in page-locked system RAM the GPU reads over PCIe,
+# and a VRAM slot cache keeps the hot experts resident (LRU, managed on the
+# device, inside the decode graphs). The cache takes whatever VRAM the KV
+# plan leaves after the context/batch you configured - lower max_ctx or
+# max_batch to give it more room; vram_gb caps it. Only k-quant expert seats
+# (Q4_K/Q5_K/Q6_K/IQ4_XS GGUFs) offload today; Q8_0 experts stay resident.
+# Needs enough RAM to hold the experts page-locked (Windows allows roughly
+# half of system RAM).
+# [moe_offload]
+# enabled = true
+# vram_gb = 6.0


### PR DESCRIPTION
## What

Serve a MoE model whose routed experts do not fit the card. Design, numbers and the ask are in #8; this is the implementation. Two commits:

1. The one-line `split.cuh` fix from #7, carried here because the pack cannot be built on Windows without it - drops out on rebase once #7 lands.
2. `engine: MoE expert offload` - under `[moe_offload] enabled = true` the k-quant expert planes are repacked as usual, then copied into device-mapped page-locked host memory (`gpu/host_plane.rs`) and the device copy freed. The MoE kernels read them over PCIe on their existing `(e*ff + o)` addressing, so no consumer kernel changes and captured decode graphs stay valid. On top, a per-layer LRU slot cache in VRAM (`gpu/moe_cache.rs`, `moe/offload.cuh`: resolve + fill, pack slots 537/538) keeps the hot experts resident and is managed on the device inside the graphs - no host round-trip on the tick.

Sizing follows the tree's rule (budgets only, the engine elects): `enable_batch` seats the cache from what the KV plan leaves after its pools and reserves, so `max_ctx` / `max_batch` stay the operator's levers; `vram_gb` caps it. The overlap decode lane stays off while the cache is on (per-layer device state, one lane). Q8 expert seats keep their VRAM residency; only k-quant seats offload today, and only the qwen35 family is wired - the mirror, cache and kernels are family-agnostic (any expert-major plane).

Not in this PR: prefill still reads experts zero-copy through the sorted lane (TTFT ~2.6 s on a 40-token prompt), MTP verify rows multiply PCIe misses so spec loses on this link, and the fixed 3 GiB `graph/prefill scratch` reserve is what caps the cache around 70 slots on a 16 GB card.

## Verified

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets` is clean on the touched crates
- [x] `cargo test --workspace` - 403 passed on the 5060 Ti (`gemm_ragged_out_dim` needs `CUDA_VISIBLE_DEVICES` on this two-card box: it opens device 0 directly, the 4060, and the sm_120-only pack has no image for it). New gates, run with `PADDOCK_PACK` + `QWEN36_MOE_UD_GGUF`: `kq_moe_pair_host_mapped_bitmatches_resident`, bit-identity host-mapped vs resident; `gpu_qwen36_moe_host`, serial end-to-end, deterministic run-to-run, prints the cache hit rate)
- Built on: Windows 11, VS 2026 with the 14.44 toolset, CUDA 13.0 pack `-Arches 120`
- GPU and driver: RTX 5060 Ti 16 GB, driver 581.80, PCIe 4.0 x8 (12.6 GB/s measured for the fill pattern)

Qwen3.6-35B-A3B UD-Q4_K_XL (22.4 GB file, 18.3 GB of experts host-mapped, 2.75 GB resident), single request, steady decode:

| config | slots/layer | tok/s |
|---|---|---|
| zero-copy only | 0 | 9 |
| max_batch 4, ctx 8192 (auto) | 60 | 51 |
| max_batch 1, ctx 8192 (auto) | 69 | 56 |
| max_batch 1, ctx 4096 (auto) | 70 | 62 |
| max_batch 1, ctx 65536 (auto) | 55 | 47 |
| warm cache, same prompt | 96 | 81 |

Per-layer LRU hit rate on a 4032-token mixed prose/code prompt: 82% at 64 slots, 90% at 96, 94% at 128. Greedy tokens identical to the resident path.

Two things seen on this card that are not this PR's: fp8 paged partial attention hd=128 splits=3 diverges 4.4e-3 from dense (deterministic; the test expects <1e-6), and the e4m3 lm_head lane (`pd_f8_gemm_lin_kernel<32,2,4,false,false,1>`) faults "Misaligned shared or local address" under compute-sanitizer with this model's Q8_0 head, so the numbers above ran with `PADDOCK_NO_F8_LMHEAD=1`. Filed as #5 and #6.



