### PR TITLE
Add the Discord to the README, CONTRIBUTING and the issue chooser

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
 blank_issues_enabled: true
 contact_links:
+  - name: Ask on Discord
+    url: https://discord.gg/fMeKkPdrsW
+    about: Questions, setup help and discussion. Bugs and model requests belong here as issues.
   - name: Documentation
     url: https://truespar.com/paddock/docs/v1/getting-started
     about: Getting started, configuration and the API surface.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,9 @@ change in.
 
 ## Where to start
 
+- **Questions** go to the [Paddock Discord](https://discord.gg/fMeKkPdrsW): setup, build
+  problems, "does this card work". Bugs stay here as issues so they are
+  searchable.
 - **Bugs and model support** are the most useful things to bring. Open an
   issue with the template; `paddock --version`, the GPU and driver, and the
   model file name are what make a report actionable.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
 # Paddock
 
+[![Discord](https://img.shields.io/badge/Discord-join%20the%20server-5865F2?logo=discord&logoColor=white)](https://discord.gg/fMeKkPdrsW)
+
 ![Paddock Studio](assets/studio-graph.gif)
+
+## Community
+
+Questions, setups that do not work, benchmark results and ideas: the Paddock
+Discord, <https://discord.gg/fMeKkPdrsW>. Bugs and model requests are best as GitHub
+issues, where the templates ask for what makes a report actionable.
 
 ## What it is
 


### PR DESCRIPTION
## What

The Paddock Discord is up, so this puts it where people look for it:

- README: a Discord badge under the title and a short Community section at the top, before "What it is". Questions and discussion go to Discord; bugs and model requests stay as issues.
- CONTRIBUTING: the same routing as the first bullet under "Where to start".
- Issue chooser (`.github/ISSUE_TEMPLATE/config.yml`): "Ask on Discord" as the first contact link, so a question does not have to become an issue.

The invite is permanent (no expiry, no use limit). The badge is static; once the server widget is enabled it can become the live member-count badge.

## Verified

Docs and repo metadata only, no code touched.

- Invite checked against Discord's public invite API: `expires_at` is null.
- README rendered locally: badge and section sit above the fold.
