### PR TITLE
Context dropdown: add "Everything that fits" with the real cap, show the shortfall on steps that don't fit, custom size field

### DIFF
--- a/studio/src/components/manage/ServerForm.vue
+++ b/studio/src/components/manage/ServerForm.vue
@@ -28,6 +28,7 @@ import { SEARCH_PROVIDERS, searchLabel, searchProvider } from '@/lib/websearch'
 import Icon from '@/components/Icon.vue'
 import Select from '@/components/ui/Select.vue'
 import NumberField from '@/components/ui/NumberField.vue'
+import { CTX_CUSTOM, CTX_MAX, CTX_STEPS, ctxCapOf, ctxFits, ctxLadder } from '@/lib/ctx-ladder'
 import FieldLabel from '@/components/manage/FieldLabel.vue'
 import TextInput from '@/components/ui/TextInput.vue'
 import Switch from '@/components/ui/Switch.vue'
@@ -815,32 +816,31 @@ const modelOptions = computed(() => [
   { value: '__custom', label: 'Other (installed name or GGUF path)...' },
 ])
 /** Every context this MODEL supports, with the ones the card cannot back
- *  greyed out and told why.
+ *  greyed out and priced, led by the fit itself and closed by Custom.
  *
  *  This list used to be filtered down to what fits, which quietly conflated two
  *  very different facts: "this model is short-context" and "your GPU is the
  *  limit here". A 256K model on a busy card would offer 8K and say nothing, so
  *  the one number the user needed - that VRAM, not the model, was the ceiling -
  *  was the number we removed. Steps beyond the MODEL's own maximum stay out:
- *  those do not exist at any VRAM. */
-const ctxSelectOptions = computed(() => {
-  const fits = new Set(ctxOptions.value)
-  const model = ctxModelCap.value
-  const steps = CTX_STEPS.filter((c) => !model || c <= model)
-  const opts = steps.map((c) => ({
-    value: c,
-    label: fmtCtx(c),
-    ...(fits.has(c) ? {} : { disabled: true, hint: 'will not fit VRAM' }),
-  }))
-  // nothing on the ladder fits: surface the exact cap so there is a choice
-  // (ctxOptions falls back to it too, so the two stay in agreement)
-  for (const c of ctxOptions.value) {
-    if (!opts.some((o) => o.value === c)) {
-      opts.unshift({ value: c, label: fmtCtx(c) })
-    }
-  }
-  return opts
-})
+ *  those do not exist at any VRAM.
+ *
+ *  The fit rung is the other half of the same lesson: the ladder is powers of
+ *  two and the card's ceiling almost never is, so a card that backs 224K used
+ *  to top out at 128K here and lose the rest in silence. The ladder itself is
+ *  pure (lib/ctx-ladder.ts) and tested there. */
+const ctxSelectOptions = computed(() =>
+  ctxLadder(
+    {
+      vramCap: ctxVramCap.value,
+      modelCap: ctxModelCap.value,
+      batch: batch.value,
+      bytesPerToken: est.value?.estimate?.kv_bytes_per_token ?? 0,
+    },
+    fmtCtx,
+    gb,
+  ),
+)
 // -1 = driver default (Select values are string|number, not null)
 const gpuOptions = computed(() => [
   { value: -1, label: 'Driver default' },
@@ -1001,7 +1001,6 @@ const WORKLOADS = [
   { id: 'team', label: 'A team / an app', batch: 16 },
 ] as const
 const CUSTOM_WORKLOAD = 'custom'
-const CTX_STEPS = [4096, 8192, 16384, 32768, 65536, 131072, 262144]
 
 // ToggleGroup speaks strings; `batch` is a number. `batchCustom` is its own
 // ref rather than derived from "does a preset own this number", because
@@ -1039,7 +1038,7 @@ function compact(n: number): string {
 }
 const ctxScale = computed(() => {
   const words = ctx.value * 0.75
-  return [
+  const out = [
     { value: compact(words), unit: 'words' },
     // "pages", not "A4 pages": A4 and US Letter hold within ~3% of the same
     // text at equal margins (62,370 vs 60,323 mm2), which is far inside the
@@ -1048,6 +1047,11 @@ const ctxScale = computed(() => {
     // accurate everywhere and one word shorter.
     { value: compact(words / 500), unit: 'pages' },
   ]
+  // Room left on the card, for whoever never opens the dropdown: the one
+  // figure that says a bigger window is a choice, not a limit.
+  if (ctxCap.value && ctx.value < ctxCap.value)
+    out.push({ value: fmtCtx(ctxCap.value), unit: 'possible on this card' })
+  return out
 })
 
 const chosenModel = computed(() =>
@@ -1264,16 +1268,56 @@ const ctxVramCap = computed(() => {
 })
 /** What the MODEL itself supports, whatever the card has. */
 const ctxModelCap = computed(() => est.value?.estimate?.model_max_ctx ?? 0)
-/** The cap that actually applies - the lower of the two. */
-const ctxCap = computed(() => {
-  if (!ctxVramCap.value) return 0
-  return ctxModelCap.value ? Math.min(ctxVramCap.value, ctxModelCap.value) : ctxVramCap.value
-})
+/** The cap that actually applies - the lower of the two, on a KV page. */
+const ctxCap = computed(() =>
+  ctxCapOf({ vramCap: ctxVramCap.value, modelCap: ctxModelCap.value }),
+)
 /** Steps that FIT: what auto-selection and clamping may choose from. */
-const ctxOptions = computed(() => {
-  if (!ctxCap.value) return CTX_STEPS
-  const opts = CTX_STEPS.filter((c) => c <= ctxCap.value)
-  return opts.length ? opts : [ctxCap.value]
+const ctxOptions = computed(() =>
+  ctxFits({ vramCap: ctxVramCap.value, modelCap: ctxModelCap.value }),
+)
+
+// How the context was chosen. The select speaks three kinds of value - a rung,
+// "everything that fits" and "custom" - and only the rung is a number the
+// form can bind directly. `ctxMode` is its own ref, like `batchCustom`: a
+// custom 131072 must stay Custom, and the fit rung must stay the fit rung
+// when the cap moves under it, neither of which a value comparison can tell.
+type CtxMode = 'ladder' | 'max' | 'custom'
+const ctxMode = ref<CtxMode>('ladder')
+const ctxPick = computed<string | number>({
+  get: () => (ctxMode.value === 'max' ? CTX_MAX : ctxMode.value === 'custom' ? CTX_CUSTOM : ctx.value),
+  set: (v) => {
+    userTouchedCtx.value = true
+    if (v === CTX_MAX) {
+      ctxMode.value = 'max'
+      if (ctxCap.value) ctx.value = ctxCap.value
+      return
+    }
+    if (v === CTX_CUSTOM) {
+      // the field opens on the current value - a starting point, not a reset
+      ctxMode.value = 'custom'
+      return
+    }
+    ctxMode.value = 'ladder'
+    ctx.value = Number(v)
+  },
+})
+/** The custom field's ceiling: the model's own maximum, or generous when the
+ *  model has not said. The runner's own will-it-fit check still guards the
+ *  load; this only stops a typo from asking for a gigatoken. */
+const ctxCustomMax = computed(() => ctxModelCap.value || 2_097_152)
+/** Under the custom field: what the card backs at this concurrency, and what
+ *  going past it means. A warning, not a clamp - the estimate is a model of
+ *  the card, and someone who measured 220K on their own box outranks it. */
+const ctxCustomHint = computed(() => {
+  const cap = ctxCap.value
+  if (!cap) return { warn: false, text: 'Any size the model supports; the will-it-fit check guards the load.' }
+  if (ctx.value > cap)
+    return {
+      warn: true,
+      text: `${fmtCtx(cap)} is the most this card backs at ${batch.value} at once - past it conversations are evicted and refilled, or the load is refused. Lower concurrency or KV precision to raise it.`,
+    }
+  return { warn: false, text: `Up to ${fmtCtx(cap)} fits at ${batch.value} at once.` }
 })
 
 // Propose a context when the MODEL or the concurrency changes - the two
@@ -1299,8 +1343,19 @@ watch([model, batch], () => {
 // Growing is now the user's move (the ladder greys out what does not fit, so
 // they can see the room appear); shrinking stays automatic, because a context
 // the card cannot back is not a choice we may leave standing.
+//
+// The fit rung is the one exception, by definition: "everything that fits" is
+// a request to follow the cap wherever it goes, up included. Custom is the
+// other way round - a number someone typed is theirs, and the hint under the
+// field says when the card disagrees.
 watch(ctxCap, (cap) => {
-  if (cap && ctx.value > cap) {
+  if (!cap) return
+  if (ctxMode.value === 'max') {
+    ctx.value = cap
+    return
+  }
+  if (ctxMode.value === 'custom') return
+  if (ctx.value > cap) {
     const fits = ctxOptions.value.filter((c) => c <= cap)
     ctx.value = fits.length ? fits[fits.length - 1] : cap
   }
@@ -1381,6 +1436,8 @@ function applySimpleConfig(cfg: SimpleCfg): void {
   if (cfg.max_ctx) {
     ctx.value = cfg.max_ctx
     userTouchedCtx.value = true
+    // a file can carry any number; the ladder only owns its rungs
+    ctxMode.value = (CTX_STEPS as readonly number[]).includes(cfg.max_ctx) ? 'ladder' : 'custom'
   }
   // the file pins by UUID; the Simple picker speaks NVML indexes - stash
   // the pin and resolve once (or if) the GPU list has landed
@@ -2225,7 +2282,13 @@ function start(): void {
         </ToggleGroup>
 
         <label class="sf__lbl">Context per conversation</label>
-        <Select v-model="ctx" :options="ctxSelectOptions" @update:model-value="userTouchedCtx = true" />
+        <Select v-model="ctxPick" :options="ctxSelectOptions" />
+        <template v-if="ctxMode === 'custom'">
+          <NumberField v-model="ctx" :min="1024" :max="ctxCustomMax" :step="1024" />
+          <p class="sf__hint" :class="{ 'sf__hint--warn': ctxCustomHint.warn }">
+            {{ ctxCustomHint.text }}
+          </p>
+        </template>
         <p class="sf__scale">
           <span v-for="f in ctxScale" :key="f.unit" class="sf__stat">
             <b class="sf__stat-v">≈{{ f.value }}</b>

--- a/studio/src/lib/ctx-ladder.test.ts
+++ b/studio/src/lib/ctx-ladder.test.ts
@@ -1,0 +1,71 @@
+// Tests for the context ladder (lib/ctx-ladder.ts).
+//
+// The ladder decides what a person can choose for the one setting that
+// most directly costs VRAM. A wrong cap refuses a context the card could
+// hold; a missing fit rung hides half the card behind powers of two.
+
+import { describe, expect, it } from 'vitest'
+import { CTX_CUSTOM, CTX_MAX, CTX_STEPS, ctxCapOf, ctxFits, ctxLadder } from './ctx-ladder'
+
+const fmt = (n: number) => `${n}`
+const gb = (b: number) => `${(b / 1e9).toFixed(1)} GB`
+
+// a 32 GB card that backs ~224K for one conversation of a 256K model
+const card = { vramCap: 229_400, modelCap: 262_144, batch: 1, bytesPerToken: 98_304 }
+
+describe('ctxCapOf', () => {
+  it('is the lower of card and model, aligned down to a KV page', () => {
+    expect(ctxCapOf(card)).toBe(229_392)
+    expect(ctxCapOf({ vramCap: 500_000, modelCap: 32_768 })).toBe(32_768)
+  })
+  it('is 0 until there is an estimate', () => {
+    expect(ctxCapOf({ vramCap: 0, modelCap: 262_144 })).toBe(0)
+  })
+  it('ignores an unknown model cap', () => {
+    expect(ctxCapOf({ vramCap: 100_010, modelCap: 0 })).toBe(100_000)
+  })
+})
+
+describe('ctxFits', () => {
+  it('is every rung when nothing is estimated', () => {
+    expect(ctxFits({ vramCap: 0, modelCap: 0 })).toEqual([...CTX_STEPS])
+  })
+  it('keeps the rungs under the cap', () => {
+    expect(ctxFits(card)).toEqual([4096, 8192, 16384, 32768, 65536, 131072])
+  })
+  it('falls back to the exact cap when no rung fits', () => {
+    expect(ctxFits({ vramCap: 3000, modelCap: 0 })).toEqual([2992])
+  })
+})
+
+describe('ctxLadder', () => {
+  it('leads with the fit rung, greys and prices what the card cannot back, ends with Custom', () => {
+    const l = ctxLadder(card, fmt, gb)
+    expect(l[0]).toEqual({ value: CTX_MAX, label: 'Everything that fits · 229392', hint: '1 at once' })
+    expect(l[l.length - 1]).toEqual({ value: CTX_CUSTOM, label: 'Custom, pick a number' })
+    const rungs = l.slice(1, -1)
+    expect(rungs.map((o) => o.value)).toEqual([...CTX_STEPS])
+    expect(rungs.filter((o) => o.disabled).map((o) => o.value)).toEqual([262_144])
+    // (262144 - 229400) tokens x 1 x 98304 B = 3.2 GB
+    expect(rungs[rungs.length - 1]?.hint).toBe('needs 3.2 GB more')
+  })
+  it('prices the shortfall per conversation at once', () => {
+    const l = ctxLadder({ ...card, batch: 4 }, fmt, gb)
+    expect(l[0]?.hint).toBe('4 at once')
+    expect(l[l.length - 2]?.hint).toBe('needs 12.9 GB more')
+  })
+  it('says will-not-fit when it cannot price it', () => {
+    const l = ctxLadder({ ...card, bytesPerToken: 0 }, fmt, gb)
+    expect(l[l.length - 2]?.hint).toBe('will not fit VRAM')
+  })
+  it('has no fit rung and nothing greyed before an estimate', () => {
+    const l = ctxLadder({ vramCap: 0, modelCap: 0, batch: 1, bytesPerToken: 0 }, fmt, gb)
+    expect(l[0]?.value).toBe(4096)
+    expect(l.some((o) => o.disabled)).toBe(false)
+    expect(l[l.length - 1]?.value).toBe(CTX_CUSTOM)
+  })
+  it('leaves out rungs past the model itself', () => {
+    const l = ctxLadder({ vramCap: 500_000, modelCap: 32_768, batch: 1, bytesPerToken: 1 }, fmt, gb)
+    expect(l.map((o) => o.value)).toEqual([CTX_MAX, 4096, 8192, 16384, 32768, CTX_CUSTOM])
+  })
+})

--- a/studio/src/lib/ctx-ladder.ts
+++ b/studio/src/lib/ctx-ladder.ts
@@ -1,0 +1,87 @@
+// The context ladder on the Start page: what the "Context per conversation"
+// select offers, computed from two facts that must never be conflated - what
+// the CARD can back at this concurrency (VRAM) and what the MODEL itself
+// supports. Pure, so the ladder can be exercised without a GPU or a store.
+//
+// Why the top rung exists: the ladder is powers of two, and the card's real
+// ceiling almost never is. On a 32 GB card that backs 224K, a ladder that only
+// offers what fits shows 128K as its top and quietly loses almost half the
+// headroom. The fit number itself is the rung people actually want.
+
+/** The fixed rungs, 4K to 256K. */
+export const CTX_STEPS = [4096, 8192, 16384, 32768, 65536, 131072, 262144] as const
+
+/** Select value for "everything that fits" - the cap itself, tracked live. */
+export const CTX_MAX = '__max'
+/** Select value for "custom" - the number field takes over. */
+export const CTX_CUSTOM = '__custom'
+
+/** KV pages hold 16 tokens (kv_pool.rs BLOCK_TOKENS); a context the pool can
+ *  back is a whole number of pages, so the fit rung is aligned down to one. */
+export const CTX_BLOCK = 16
+
+export interface CtxLadderInput {
+  /** Tokens per conversation VRAM backs at this concurrency; 0 = not estimated. */
+  vramCap: number
+  /** The model's own maximum context; 0 = unknown. */
+  modelCap: number
+  /** Conversations at once - the multiplier on every KV byte. */
+  batch: number
+  /** KV bytes per token per conversation; 0 = unknown (no shortfall figure). */
+  bytesPerToken: number
+}
+
+export interface CtxOption {
+  value: number | string
+  label: string
+  hint?: string
+  disabled?: boolean
+}
+
+/** The cap that applies - the lower of the card and the model - aligned down
+ *  to a KV page. 0 while there is no estimate. */
+export function ctxCapOf(i: Pick<CtxLadderInput, 'vramCap' | 'modelCap'>): number {
+  if (!i.vramCap) return 0
+  const cap = i.modelCap ? Math.min(i.vramCap, i.modelCap) : i.vramCap
+  return Math.max(CTX_BLOCK, cap - (cap % CTX_BLOCK))
+}
+
+/** The rungs that FIT - what auto-selection and clamping may choose from.
+ *  Falls back to the exact cap when nothing on the ladder does. */
+export function ctxFits(i: Pick<CtxLadderInput, 'vramCap' | 'modelCap'>): number[] {
+  const cap = ctxCapOf(i)
+  if (!cap) return [...CTX_STEPS]
+  const opts = CTX_STEPS.filter((c) => c <= cap)
+  return opts.length ? opts : [cap]
+}
+
+/** Everything the select shows, top to bottom: the fit rung (when estimated),
+ *  the model's rungs with the ones VRAM cannot back greyed and priced, and
+ *  Custom. Rungs past the model's own maximum stay out - those do not exist
+ *  at any VRAM.
+ *
+ *  `fmt` renders a token count ("224K"), `gb` a byte count ("6.1 GB"). */
+export function ctxLadder(
+  i: CtxLadderInput,
+  fmt: (tokens: number) => string,
+  gb: (bytes: number) => string,
+): CtxOption[] {
+  const cap = ctxCapOf(i)
+  const steps = CTX_STEPS.filter((c) => !i.modelCap || c <= i.modelCap)
+  const rungs: CtxOption[] = steps.map((c) => {
+    if (!cap || c <= cap) return { value: c, label: fmt(c) }
+    // Priced, not just refused: the number that tells someone what lowering
+    // concurrency or KV precision would have to buy back.
+    const short = i.bytesPerToken > 0 ? (c - i.vramCap) * Math.max(1, i.batch) * i.bytesPerToken : 0
+    return {
+      value: c,
+      label: fmt(c),
+      disabled: true,
+      hint: short > 0 ? `needs ${gb(short)} more` : 'will not fit VRAM',
+    }
+  })
+  const top: CtxOption[] = cap
+    ? [{ value: CTX_MAX, label: `Everything that fits · ${fmt(cap)}`, hint: `${Math.max(1, i.batch)} at once` }]
+    : []
+  return [...top, ...rungs, { value: CTX_CUSTOM, label: 'Custom, pick a number' }]
+}


### PR DESCRIPTION
## What

The ladder is powers of two and the card's ceiling never is, so a 5090 that holds 224K topped out at 128K. The top entry is now the cap itself and follows concurrency and KV precision live. Steps the card can't back stay in the list, greyed, with how many GB they'd need. Custom opens a number field and warns past the cap instead of clamping, the runner still guards the load. Ladder logic in `lib/ctx-ladder.ts` with tests.

What the select shows now, top to bottom:

```
Everything that fits · 224K     the cap, tracked live
256K                            greyed, "needs 3.2 GB more"
128K
...
4K
Custom, pick a number           opens a number field on the current value
```

The scale line under it gains "≈224K possible on this card" while the choice is under the cap. An edited file whose max_ctx is off the ladder prefills as Custom.

First asked for by a 5090 user on Discord who measured 220K as his sweet spot and had no way to pick it.

## Verified

- [x] `cd studio && npm run build && npm test` (vue-tsc, vite build, vitest 29 passed, 11 of them new for the ladder)
- Built on: macOS (Studio only, no Rust touched)
- Not run against a live manager: the Start page needs a card behind it. Worth one look on a box with a GPU before merge.
