### PR TITLE
qwen35: configurable graph/prefill scratch reserve

### DIFF
--- a/crates/paddock-engine/src/gpu_model/gpt_oss.rs
+++ b/crates/paddock-engine/src/gpu_model/gpt_oss.rs
@@ -1141,7 +1141,10 @@ impl GpuGptOss {
                 ),
                 // prefill/graph-capture scratch + allocator headroom (the qwen35
                 // sizer's measured margin on this card class)
-                kv_plan::Reserve::new("graph/prefill scratch", 3 * 1024 * 1024 * 1024),
+                kv_plan::Reserve::new(
+                    "graph/prefill scratch",
+                    crate::kv_plan::graph_scratch_reserve_bytes(),
+                ),
             ],
             // qwen35's Issue-2 guard: a pool that cannot back --max-ctx ×
             // --max-batch refuses loudly rather than under-sizing into unbounded

--- a/crates/paddock-engine/src/gpu_model/qwen35/batch.rs
+++ b/crates/paddock-engine/src/gpu_model/qwen35/batch.rs
@@ -382,7 +382,10 @@ impl GpuQwen35 {
                 // prefill scratch + graph pools + allocator headroom. The width
                 // sizer's 1.5 GB margin is a different, separately-measured
                 // budget - see width_by_vram.
-                kv_plan::Reserve::new("graph/prefill scratch", 3 * 1024 * 1024 * 1024),
+                kv_plan::Reserve::new(
+                    "graph/prefill scratch",
+                    crate::kv_plan::graph_scratch_reserve_bytes(),
+                ),
                 kv_plan::Reserve::new(
                     "kv-tier staging",
                     if crate::kv_tier::pool_tier::tier_ram_bytes().is_some() {

--- a/crates/paddock-engine/src/kv_plan.rs
+++ b/crates/paddock-engine/src/kv_plan.rs
@@ -75,6 +75,21 @@ impl Reserve {
         Self { what, bytes }
     }
 }
+/// The `graph/prefill scratch` reserve, settable by the operator: the fixed
+/// 3 GiB default is sized for 16-48 GB cards and starves 8 GB cards of both
+/// KV and - since `[moe_offload]` - the slot cache the plan's leftovers seat.
+static GRAPH_SCRATCH_MIB: std::sync::OnceLock<u64> = std::sync::OnceLock::new();
+/// Arm the override once before any model loads (the same shape as
+/// `pool_tier::set_tier_ram_bytes` / `gpu::set_moe_offload`). `None` = keep
+/// the 3 GiB default.
+pub fn set_graph_scratch_mib(mib: u64) {
+    let _ = GRAPH_SCRATCH_MIB.set(mib);
+}
+/// The armed override, or the 3 GiB default. Both production call sites
+/// (qwen35 and gpt-oss `graph/prefill scratch` reserves) charge this.
+pub fn graph_scratch_reserve_bytes() -> u64 {
+    GRAPH_SCRATCH_MIB.get().copied().unwrap_or(3 * (1 << 30))
+}
 
 /// What to do when the grant cannot back a full `max_ctx` for every slot asked
 /// for. See the module note - this is the open policy question, not a detail.

--- a/crates/paddock-runner/src/config.rs
+++ b/crates/paddock-runner/src/config.rs
@@ -108,6 +108,12 @@ pub struct Config {
     pub kv_offload: KvOffload,
     /// See [`MoeOffload`].
     pub moe_offload: MoeOffload,
+    /// Override the fixed 3 GiB `graph/prefill scratch` KV-plan reserve, in
+    /// MiB. The default is sized for 16-48 GB cards; on 8 GB cards it alone
+    /// exhausts the grant and starves both the KV pool and the
+    /// `[moe_offload]` slot cache (which is sized from the plan's leftovers).
+    /// None = keep the 3 GiB default.
+    pub graph_scratch_mib: Option<u64>,
     /// Default max output tokens per reply when a request doesn't specify.
     pub max_tokens: Option<usize>,
     /// API key for Bearer auth. Empty + loopback bind = no auth; empty +
@@ -323,6 +329,7 @@ impl Default for Config {
             vram_budget: None,
             kv_offload: KvOffload::default(),
             moe_offload: MoeOffload::default(),
+            graph_scratch_mib: None,
             max_tokens: None,
             api_key: None,
             no_auth: false,
@@ -471,6 +478,12 @@ impl Config {
         }
         if let Some(v) = env_str("PADDOCK_DEVICE") {
             self.device = v;
+        }
+        if let Some(v) = env_str("PADDOCK_GRAPH_SCRATCH_MIB") {
+            self.graph_scratch_mib = Some(
+                v.parse()
+                    .map_err(|_| bad_env("PADDOCK_GRAPH_SCRATCH_MIB", &v))?,
+            );
         }
         if let Some(v) = env_str("PADDOCK_GPU") {
             self.gpu = Some(v);
@@ -670,6 +683,7 @@ pub const ENV_SURFACE: &[&str] = &[
     "PADDOCK_FORCE_PARAMS",
     "PADDOCK_FP8_NATIVE",
     "PADDOCK_GPU",
+    "PADDOCK_GRAPH_SCRATCH_MIB",
     "PADDOCK_HOST",
     "PADDOCK_KERNEL_PACK",
     "PADDOCK_KV_CACHE_DTYPE",
@@ -785,6 +799,15 @@ mod tests {
         // key requirement for non-loopback peers (auth_mw) is the guard.
         let cfg = Config::default();
         assert!(cfg.host.is_unspecified(), "default must serve the network");
+    }
+    #[test]
+    fn graph_scratch_mib_parses_and_defaults_to_none() {
+        // absent -> None (the 3 GiB engine default stands)
+        let c: Config = toml::from_str("").expect("empty config");
+        assert!(c.graph_scratch_mib.is_none());
+        // explicit value
+        let c: Config = toml::from_str("graph_scratch_mib = 512").expect("parse");
+        assert_eq!(c.graph_scratch_mib, Some(512));
     }
 
     #[test]

--- a/crates/paddock-runner/src/lib.rs
+++ b/crates/paddock-runner/src/lib.rs
@@ -252,6 +252,13 @@ pub async fn run(
             "[moe_offload] MoE expert offload armed (slot cache auto-sized from the KV plan's leftover unless vram_gb caps it)"
         );
     }
+    if let Some(mib) = cfg.graph_scratch_mib {
+        paddock_engine::kv_plan::set_graph_scratch_mib(mib);
+        tracing::info!(
+            graph_scratch_mib = mib,
+            "graph/prefill scratch reserve overridden (default 3072 MiB)"
+        );
+    }
     if ram_armed {
         tracing::info!(
             ram_gb = kv.ram_gb,

--- a/crates/paddock-runner/src/startup.rs
+++ b/crates/paddock-runner/src/startup.rs
@@ -142,6 +142,10 @@ pub struct Cli {
     /// can't fit it refuses (co-resident servers can't oversubscribe the card)
     #[arg(long = "vram-budget", value_name = "MIB")]
     pub vram_budget: Option<u64>,
+    /// Override the fixed 3 GiB graph/prefill scratch KV-plan reserve, in MiB
+    /// (8 GB cards: the default starves KV and the moe_offload slot cache)
+    #[arg(long = "graph-scratch-mib", value_name = "MIB")]
+    pub graph_scratch_mib: Option<u64>,
     /// Default max output tokens per reply (when a request doesn't specify)
     #[arg(long = "max-output-tokens", value_name = "N")]
     pub max_output_tokens: Option<usize>,
@@ -465,6 +469,9 @@ pub fn resolve(cli: &Cli) -> Result<(Config, Banner), ConfigError> {
     }
     if let Some(b) = cli.vram_budget {
         cfg.vram_budget = Some(b);
+    }
+    if let Some(m) = cli.graph_scratch_mib {
+        cfg.graph_scratch_mib = Some(m);
     }
     if let Some(n) = cli.max_output_tokens {
         cfg.max_tokens = Some(n);

--- a/paddock.example.toml
+++ b/paddock.example.toml
@@ -139,6 +139,6 @@
 # default is sized for 16-48 GB cards; on an 8 GB card it alone eats the whole
 # grant - and the moe_offload slot cache is sized from what the plan leaves.
 # Lower it on small cards (the engine still refuses loudly if the real
-# prefill/graph scratch does not fit). Set --graph-scratch-mib / env
-# PADDOCK_GRAPH_SCRATCH_MIB the same way.
+# prefill/graph scratch does not fit).
+# Env: PADDOCK_GRAPH_SCRATCH_MIB   CLI: --graph-scratch-mib
 # graph_scratch_mib = 512

--- a/paddock.example.toml
+++ b/paddock.example.toml
@@ -134,3 +134,11 @@
 # [moe_offload]
 # enabled = true
 # vram_gb = 6.0
+
+# Override the fixed 3 GiB "graph/prefill scratch" KV-plan reserve (MiB). The
+# default is sized for 16-48 GB cards; on an 8 GB card it alone eats the whole
+# grant - and the moe_offload slot cache is sized from what the plan leaves.
+# Lower it on small cards (the engine still refuses loudly if the real
+# prefill/graph scratch does not fit). Set --graph-scratch-mib / env
+# PADDOCK_GRAPH_SCRATCH_MIB the same way.
+# graph_scratch_mib = 512


### PR DESCRIPTION
## What

The fixed 3 GiB `graph/prefill scratch` KV-plan reserve (`qwen35/batch.rs`, `gpt_oss.rs`) is sized for 16-48 GB cards. On an 8 GB card it alone exhausts the grant — and since #9 it also starves the `[moe_offload]` slot cache, which is sized from what the KV plan leaves.

This makes the reserve a first-class knob, in the same shapes as the existing config surface:

- `kv_plan::set_graph_scratch_mib` + `graph_scratch_reserve_bytes()` — armed once before load, the same pattern as `gpu::set_moe_offload` / `pool_tier::set_tier_ram_bytes`; both production call sites (qwen35, gpt-oss) charge it.
- `graph_scratch_mib` config field (serde, `deny_unknown_fields` respected), `--graph-scratch-mib` CLI flag, `PADDOCK_GRAPH_SCRATCH_MIB` env — declared in `ENV_SURFACE` (the drift-guard test enforces that).
- `paddock.example.toml` doc block, config parse test.

Unset = the 3 GiB default stands. The engine still refuses loudly when the real prefill/graph scratch does not fit.

## Why: measured on a named board

RTX 3070 8 GB (sm_86, PCIe 3.0 x16), driver 595.99.02, Qwen3.6-35B-A3B UD-Q4_K_M (22.1 GB file), `[moe_offload] enabled = true`, upstream `ac58ede`, multi-arch pack built with CUDA 13.1.115, 128-token decode, HTTP streaming:

| config | result |
|---|---|
| `[moe_offload]` as shipped (default reserve) | **refuses**: `cannot serve max_ctx 2048: needs 0.55 GiB of KV, only 0.00 GiB fits` |
| + `graph_scratch_mib = 256`, `vram_gb = 1.0`, `max_batch = 1` | **serves**: 31.4-32.3 tok/s warm, VRAM 6841 MiB |
| same, cache disabled (`PADDOCK_MOE_CACHE_SLOTS=0`) | 19.2-20.4 tok/s (pure zero-copy) |

So on this board the slot cache is worth **+60%** over zero-copy — but it is unreachable without shrinking the reserve, because the plan leaves 0.00 GiB.

Against what: the zero-copy numbers agree with #9's shape (their RTX 5060 Ti 16 GB / PCIe 4.0 x8: 9 tok/s zero-copy → 51-62 with slots); this adds the 8 GB / PCIe 3.0 point and the reserve interaction.

## Side finding (not in this diff)

On 8 GB, `enable_batch(32)` OOMs and the `32 → 16 → 1` width-retry ladder then reports `0.0 GB free after weights` — the failed attempt's allocations are not released, so every retry refuses regardless of config. `max_batch = 1` in config bypasses the ladder and serves. Happy to file an issue with the full evidence if useful.

## Tests

- `cargo fmt --all --check` clean
- `cargo clippy --workspace --all-targets` clean
- `cargo test -p paddock-runner --lib` → 486 passed (incl. new `graph_scratch_mib_parses_and_defaults_to_none` and the ENV_SURFACE drift guard)
- `cargo test -p paddock-engine` → 373+ passed
- Serving evidence above from a real pack + card; no new kernels added