### PR TITLE
qwen35: release a failed enable_batch attempt before the width ladder retries

### DIFF
--- a/crates/paddock-engine/src/gpu_model/qwen35/batch.rs
+++ b/crates/paddock-engine/src/gpu_model/qwen35/batch.rs
@@ -218,6 +218,21 @@ impl GpuQwen35 {
     /// slot i. Returns the enabled capacity.
     pub fn enable_batch(&mut self, max_batch: usize) -> Result<usize, GpuModelError> {
         assert!(max_batch >= 1);
+        let r = self.enable_batch_sized(max_batch);
+        if r.is_err() {
+            // A failed attempt leaves what it already seated (BatchState with
+            // its pool + tier, per-layer MoE caches, overlap stream, dflash
+            // device state, scratch) holding VRAM. The width ladder then reads
+            // "0.0 GB free after weights" and every halved retry refuses
+            // regardless of width - measured on an 8 GB card (RTX 3070):
+            // enable_batch(32) OOM mid-way, 32->16->1 all dead, startup fatal.
+            // Release the attempt before the error reaches the ladder.
+            self.release_batch_attempt();
+        }
+        r
+    }
+
+    fn enable_batch_sized(&mut self, max_batch: usize) -> Result<usize, GpuModelError> {
         let (max_batch, spec_live_cap) = self.width_by_vram(max_batch);
         // spec live degraded to buy width (see width_by_vram) - ensure_serve_spec
         // allocates at this cap instead of the env default

--- a/crates/paddock-engine/src/gpu_model/qwen35/mod.rs
+++ b/crates/paddock-engine/src/gpu_model/qwen35/mod.rs
@@ -1199,6 +1199,37 @@ impl GpuQwen35 {
             .iter()
             .any(|l| matches!(&l.ffn, Ffn::Moe(m) if m.cache.is_some()))
     }
+    /// Release everything a failed `enable_batch` attempt seated. The
+    /// width-retry ladder halves the width and calls again; a half-built
+    /// attempt holding its BatchState (pool + tier), per-layer MoE caches,
+    /// overlap stream, dflash device state and scratch reads as
+    /// `0.0 GB free after weights`, and every retry then refuses regardless
+    /// of width. Same teardown list as `set_kv_dtype` (the established
+    /// "nuke serving state" precedent) plus what only `enable_batch` seats;
+    /// the attached DFlash drafter survives - only its device state drops,
+    /// `dflash_ensure_state` rebuilds it on the next attempt.
+    pub(super) fn release_batch_attempt(&mut self) {
+        self.pipe_abort();
+        self.batch = None;
+        self.spec = None;
+        self.spec_batch = None;
+        self.scratch = None;
+        self.overlap_exec = None;
+        if let Some(df) = &mut self.dflash {
+            df.state = None;
+        }
+        for layer in &mut self.layers {
+            if let Ffn::Moe(m) = &mut layer.ffn {
+                m.cache = None;
+            }
+        }
+        if let Some(mtp) = &mut self.mtp {
+            if let Ffn::Moe(m) = &mut mtp.ffn {
+                m.cache = None;
+            }
+        }
+        self.exec.trim_mem_pool();
+    }
 
     /// Cache counters summed over the layers: `(rows resolved, misses)` since
     /// load; `None` without a cache. Syncs the stream - for gates and logs.


### PR DESCRIPTION
## What

`enable_batch` seats its state progressively: `self.batch` (BatchState with the paged KV pool + tier), the per-layer MoE slot caches, the overlap stream, the DFlash device state, and the scratch arena. A mid-way OOM returned `Err` — but left all of it holding VRAM. The width-retry ladder (`service.rs`, halves the width and calls again) then read `0.0 GB free after weights` and **every halved retry refused regardless of width**.

This rolls a failed attempt back before the error reaches the ladder: `release_batch_attempt()` uses the same teardown list as the established `set_kv_dtype` precedent (pipe_abort, batch/spec/spec_batch/scratch = None) plus what only `enable_batch` seats (per-layer and MTP slot caches, overlap stream). The attached DFlash drafter survives — only its device state drops, and `dflash_ensure_state` rebuilds it on the next attempt.

## Why: measured on a named board

RTX 3070 8 GB (sm_86, PCIe 3.0 x16), driver 595.99.02, Qwen3.6-35B-A3B UD-Q4_K_M, `[moe_offload] enabled` + `vram_gb = 1.0` (the tightest card class where the ladder actually gets exercised), multi-arch pack from CUDA 13.1.115, upstream `ac58ede` + the `graph_scratch_mib` knob from #14 for headroom:

Before (no rollback):

```
width-by-VRAM: max_batch 32 -> 14 (4.8 GB free after weights ...)
enable_batch(32) failed: GPU out of memory (CUDA_ERROR_OUT_OF_MEMORY)
retrying continuous batching at width 16
width-by-VRAM: max_batch 16 -> 1 (0.0 GB free after weights ...)   <- poisoned
qwen35 cannot serve max_ctx 2048 ... only 0.00 GiB fits            <- fatal
```

After (this diff):

```
width-by-VRAM: max_batch 32 -> 14 ...
enable_batch(32) failed: GPU out of memory (CUDA_ERROR_OUT_OF_MEMORY)
retrying continuous batching at width 16
width-by-VRAM: max_batch 16 -> 13 (...)                            <- real free VRAM again
enable_batch(16) failed: GPU out of memory (CUDA_ERROR_OUT_OF_MEMORY)
retrying continuous batching at width 8
qwen35 MoE expert offload: VRAM slot cache seated slots=13 cache_gib=0.97
listening                                                          <- serves at width 8
```

Steady decode on the same board: **31.4-33.3 tok/s warm** at batch width 8 (the pre-fix config only served with `max_batch = 1` forced in config, 31.4-32.3 tok/s). Correct generations verified (17×23=391).

## Tests

- `cargo fmt --all --check` clean; `cargo clippy --workspace` clean
- `cargo test -p paddock-engine` → 373+ passed (no GPU-required assertions added; the fix is exercised by the serving path evidence above)
- No new kernels; behavior change is confined to the `enable_batch` error path
- Independent of #14 (the fix applies to any family whose `enable_batch` can OOM mid-way; the evidence uses #14's knob only to reach the tightest config honestly)