### PR TITLE
cuda+engine: dense i-quant planes ride the >64-row W4A8 tile (pipe2) - prefill 59 -> 1186 tok/s on the 9B UD-IQ2_XXS

### DIFF
--- a/crates/paddock-engine/src/gpu/kquant.rs
+++ b/crates/paddock-engine/src/gpu/kquant.rs
@@ -63,6 +63,13 @@ impl GpuExecutor {
         self.kernels.kquant_iq_dense.is_some()
     }
 
+    /// The >64-row W4A8 tile GEMM (`kquant_gemm_w4a8_pipe2`) serves the
+    /// i-quant family + Q2_K / Q3_K / IQ4_NL (slot 580): prefill on a dense
+    /// i-quant plane rides the tile instead of re-reading the plane per token.
+    pub fn has_kquant_iq_tile(&self) -> bool {
+        self.kernels.kquant_iq_tile.is_some()
+    }
+
     /// True when the pack carries the K-split W4A8 mma rung (appended after
     /// the base k-quant family - older packs fall back to the dp4a z-tiling).
     pub fn has_kquant_mma_ks(&self) -> bool {

--- a/crates/paddock-engine/src/gpu/kquant.rs
+++ b/crates/paddock-engine/src/gpu/kquant.rs
@@ -635,13 +635,27 @@ impl GpuExecutor {
         y: &mut CudaSlice<f32>,
         batch: usize,
     ) -> Result<(), GpuError> {
+        self.kquant_gemm_w4a8_pipe2_rows(w, yq, xsums, y, 0, batch)
+    }
+
+    /// [`Self::kquant_gemm_w4a8_pipe2`] writing from row `y_row0` of `y` -
+    /// a chunk-sized `yq` landing in its rows of a wider output.
+    pub fn kquant_gemm_w4a8_pipe2_rows(
+        &self,
+        w: &RepackedKQ,
+        yq: &CudaSlice<u8>,
+        xsums: Option<&CudaSlice<f32>>,
+        y: &mut CudaSlice<f32>,
+        y_row0: usize,
+        batch: usize,
+    ) -> Result<(), GpuError> {
         let f = self
             .kernels
             .kquant_gemm_w4a8_pipe2
             .ok_or(GpuError::MissingOp("kquant_gemm_w4a8_pipe2"))?;
         let (raw_id, _, _) = kq_params(w.ty).expect("RepackedKQ holds a k-quant type");
         let (in_dim, out_dim) = (w.dims[0], w.dims[1]);
-        debug_assert!(y.len() >= out_dim * batch);
+        debug_assert!(y.len() >= out_dim * (y_row0 + batch));
         let (dp, _g1) = w.data.device_ptr(&self.stream);
         let (scp, _g2) = w.scales.device_ptr(&self.stream);
         let (yqp, _g3) = yq.device_ptr(&self.stream);
@@ -661,7 +675,7 @@ impl GpuExecutor {
                 scp as *const _,
                 yqp as *const _,
                 sp,
-                yp as *mut _,
+                (yp + (y_row0 * out_dim * 4) as u64) as *mut _,
                 in_dim as u32,
                 out_dim as u32,
                 batch as u32,

--- a/crates/paddock-engine/src/gpu/q8_gemm.rs
+++ b/crates/paddock-engine/src/gpu/q8_gemm.rs
@@ -657,15 +657,29 @@ impl GpuExecutor {
         in_dim: usize,
         batch: usize,
     ) -> Result<(), GpuError> {
+        self.quantize_q8_mmq_rows(x, 0, yq, in_dim, batch)
+    }
+
+    /// [`Self::quantize_q8_mmq`] from row `x_row0` of `x` - a chunk of a
+    /// wider activation quantized into a chunk-sized `yq`.
+    pub fn quantize_q8_mmq_rows(
+        &self,
+        x: &CudaSlice<f32>,
+        x_row0: usize,
+        yq: &mut CudaSlice<u8>,
+        in_dim: usize,
+        batch: usize,
+    ) -> Result<(), GpuError> {
         let f = self
             .kernels
             .quantize_q8_mmq
             .ok_or(GpuError::MissingOp("quantize_q8_mmq"))?;
+        debug_assert!(x.len() >= (x_row0 + batch) * in_dim);
         let (xp, _g1) = x.device_ptr(&self.stream);
         let (yp, _g2) = yq.device_ptr_mut(&self.stream);
         check(unsafe {
             f(
-                xp as *const _,
+                (xp + (x_row0 * in_dim * 4) as u64) as *const _,
                 yp as *mut _,
                 in_dim as u32,
                 batch as u32,

--- a/crates/paddock-engine/src/gpu_model/qwen35/ops.rs
+++ b/crates/paddock-engine/src/gpu_model/qwen35/ops.rs
@@ -1822,12 +1822,12 @@ pub(crate) fn prefill_quant(
 ) -> Result<(), GpuModelError> {
     if batch > 64 {
         exec.quantize_q8_mmq(x, yq, in_dim, batch)?;
-        // A dense i-quant plane has no mmq tile lane yet and reads the
-        // row-major int8 pair at every width (kq_mm_pre); until the tile lane
-        // lands, files that carry such a plane pay one extra memory-bound
-        // pass here. Measured 2026-09-06 without it: the >64-row route read
-        // stale xq and a 110-token prompt decoded to gibberish.
-        if exec.dense_iq_seen() {
+        // A pack without the i-quant tile rung (slot 580) keeps a dense
+        // i-quant plane on the row-major dp4a walk at every width
+        // (kq_mm_pre), so such a file pays one extra memory-bound pass here.
+        // Measured 2026-09-06 without it: the >64-row route read stale xq
+        // and a 110-token prompt decoded to gibberish.
+        if iq_rowmajor_needed(exec) {
             exec.quantize_q8(x, xq, xs, batch * in_dim)?;
         }
     } else {
@@ -2078,18 +2078,13 @@ pub(crate) fn kq_mm_pre(
     batch: usize,
 ) -> Result<(), GpuModelError> {
     let needs = crate::gpu::kq_needs_sums(k.ty);
-    // The W4A8 tile GEMMs (pipe / pipe2 / the plain w4a8) stage raw k-quant
-    // super-blocks and have no i-quant tile loader - the pack refuses the
-    // type with cudaErrorInvalidValue - so an i-quant plane takes the dp4a
-    // lane at EVERY width. Measured 2026-09-06 on Qwen3.5-9B UD-IQ2_XXS:
-    // any prompt past 64 tokens died with "CUDA error 1" before this.
-    //
-    // INTERIM, NOT SOTA: the i-quant dp4a lane re-reads the weight plane
-    // once per token (warp per (row, token)), so a 2048-token chunk costs
-    // 2048x the plane's bytes. The target is an int8-mma tile lane whose
-    // loader unpacks i-quant windows into the mma_ks / pipe2 smem tiles;
-    // until it exists, prefill on dense i-quant files is correct and slow.
-    if batch > 64 && !crate::gpu::kq_is_iq(k.ty) {
+    // An i-quant plane rides the tile rung only when the pack's pipe2 builds
+    // its tile through the i-quant window unpack (slot 580); a pack without
+    // it refuses the type with cudaErrorInvalidValue, and the plane stays
+    // on the dp4a walk at every width - correct, but re-reading the plane
+    // once per token (any prompt past 64 tokens died with "CUDA error 1"
+    // before the guard, 2026-09-06, Qwen3.5-9B UD-IQ2_XXS).
+    if batch > 64 && kq_tile_ok(exec, k) {
         if needs {
             exec.mmq_sums(yq, xsums, k.dims[0], batch)?;
         }
@@ -2111,6 +2106,22 @@ pub(crate) fn kq_mm_pre(
         exec.kquant_gemm_dp4a(k, xq, xs, needs.then_some(&*ssums), y, batch)?;
     }
     Ok(())
+}
+
+/// The plane may take the >64-row W4A8 tile: every k-quant type, and the
+/// i-quant family when the pack's tile builds through the window unpack
+/// (slot 580).
+pub(crate) fn kq_tile_ok(exec: &GpuExecutor, k: &RepackedKQ) -> bool {
+    // IQ4_NL rows lie flat at any multiple of 32; the tile walks whole
+    // super-blocks, so such a width stays on the dp4a lane
+    !crate::gpu::kq_is_iq(k.ty) || (exec.has_kquant_iq_tile() && k.dims[0].is_multiple_of(256))
+}
+
+/// True when a dense i-quant plane was loaded and the pack cannot tile it:
+/// the >64-row producers then keep the row-major int8 pair for the dp4a
+/// walk as well as the mmq tiles.
+pub(crate) fn iq_rowmajor_needed(exec: &GpuExecutor) -> bool {
+    exec.dense_iq_seen() && !exec.has_kquant_iq_tile()
 }
 
 /// QuantW dispatch over [`prefill_mm_pre`] - Q8_0 keeps its exact ladder,
@@ -2179,11 +2190,12 @@ pub(crate) fn prefill_ffn_down_any(
     match w {
         QuantW::Q8(q) => prefill_ffn_down(exec, q, xq, xs, yq, skfix, gate, up, y, ff, batch),
         QuantW::Kq(k) => {
-            // the fused swiglu+quantize writes ONLY the mmq tiles; an i-quant
-            // down plane reads the row-major pair (kq_mm_pre), so it takes the
-            // two-step form at every width - this was the site that fed stale
-            // xq to a 110-token prompt and decoded gibberish (2026-09-06)
-            if batch > 64 && !crate::gpu::kq_is_iq(k.ty) {
+            // the fused swiglu+quantize writes ONLY the mmq tiles; a down
+            // plane the pack cannot tile reads the row-major pair (kq_mm_pre),
+            // so it takes the two-step form at every width - this was the
+            // site that fed stale xq to a 110-token prompt and decoded
+            // gibberish (2026-09-06)
+            if batch > 64 && kq_tile_ok(exec, k) {
                 exec.quantize_q8_mmq_swiglu(gate, up, yq, k.dims[0], batch)?;
             } else {
                 exec.swiglu(gate, up, batch * ff)?;
@@ -2285,11 +2297,11 @@ pub(crate) fn prefill_add_norm_quant(
 ) -> Result<(), GpuModelError> {
     if batch > 64 && n.is_multiple_of(4) && n <= 24576 {
         // The fused kernel writes the mmq tiles (yq) only. A dense i-quant
-        // plane downstream reads the row-major pair (kq_mm_pre), so keep xn
-        // and quantize it as well - the width bisect on Qwen3.5-9B UD-IQ2_XXS
-        // (2026-09-06) passed at 64 rows and decoded gibberish at 65, and this
-        // was the site. Interim until the i-quant mma tile lane (prefill_quant).
-        let iq = exec.dense_iq_seen();
+        // plane the pack cannot tile reads the row-major pair downstream
+        // (kq_mm_pre), so keep xn and quantize it as well - the width bisect
+        // on Qwen3.5-9B UD-IQ2_XXS (2026-09-06) passed at 64 rows and decoded
+        // gibberish at 65, and this was the site.
+        let iq = iq_rowmajor_needed(exec);
         let xn_opt = if write_xn || iq { Some(&mut *xn) } else { None };
         exec.add_rmsnorm_quant_mmq(x, proj, proj_b16, w, xn_opt, yq, n, batch, eps)?;
         if iq {

--- a/crates/paddock-engine/src/gpu_model/qwen4exp/forward.rs
+++ b/crates/paddock-engine/src/gpu_model/qwen4exp/forward.rs
@@ -787,6 +787,18 @@ impl Qwen4ExpGpu {
             } else {
                 1
             })?,
+            // the > 64-row tile's mmq tiles for one KQ_TILE_ROWS-row chunk:
+            // 144 B per (128-wide k chunk, row), and 4 per-32 sums per pair
+            yq: exec.alloc_u8(if kq_lanes {
+                cfg.hc_width().div_ceil(128) * super::KQ_TILE_ROWS * 144
+            } else {
+                1
+            })?,
+            xsums: exec.alloc(if kq_lanes {
+                cfg.hc_width().div_ceil(128) * super::KQ_TILE_ROWS * 4
+            } else {
+                1
+            })?,
             // the widest activation any dense plane reads is the 4-stream state
             x16: exec.alloc_f16(max_tokens * cfg.hc_width())?,
             xb16: exec.stream_alloc_bf16(max_tokens * cfg.hc_width())?,

--- a/crates/paddock-engine/src/gpu_model/qwen4exp/mod.rs
+++ b/crates/paddock-engine/src/gpu_model/qwen4exp/mod.rs
@@ -232,6 +232,12 @@ pub struct DenseStage {
     /// partials the ks GEMM wants. Empty (len 0) when no Kq plane loaded.
     pub xs: CudaSlice<f32>,
     pub ssums: CudaSlice<f32>,
+    /// `Kq` class above 64 rows: the mmq-layout int8 tiles
+    /// (`quantize_q8_mmq`) and their per-32 sums the W4A8 tile GEMM reads,
+    /// for one `KQ_TILE_ROWS`-row chunk of the widest dense plane (the
+    /// launch loops over chunks); len 1 without Kq.
+    pub yq: CudaSlice<u8>,
+    pub xsums: CudaSlice<f32>,
     /// f16 view of the activation the F16 class feeds `pd_f16_gemm`. One cast
     /// per (plane, tick); the same buffer serves every plane because the walk
     /// is strictly sequential inside a layer.
@@ -1008,6 +1014,10 @@ impl DensePlane {
 /// quantize per-32 into `stage.q`/`stage.xs` and the int8 dp4a GEMM runs
 /// (the Q4/Q5 min term needs the per-16 sums). Q8_0 planes take the
 /// repacked GEMM off f32 rows directly, as qwen35's `mm_q8` does.
+/// Rows per launch of the > 64-row W4A8 tile in [`kq_matmul`]: four tile
+/// columns, so the mmq scratch stays a few MB at any context length.
+pub(crate) const KQ_TILE_ROWS: usize = 512;
+
 fn kq_matmul(
     e: &GpuExecutor,
     w: &QuantW,
@@ -1038,6 +1048,43 @@ fn kq_matmul(
                 )));
             }
             let needs = crate::gpu::kq_needs_sums(k.ty);
+            // > 64 rows: the mmq tiles and the W4A8 tile GEMM - the qwen35
+            // prefill rung (`kq_mm_pre`) - read the plane once per 128-column
+            // tile where the dp4a walk below reads it once per token, in
+            // KQ_TILE_ROWS-row chunks off a fixed scratch. An i-quant plane
+            // needs the pack's window-unpack tile (slot 580).
+            let iq = crate::gpu::kq_is_iq(k.ty);
+            let chunk_rows = in_dim.div_ceil(128) * KQ_TILE_ROWS;
+            if batch > 64
+                && in_dim.is_multiple_of(256)
+                && e.has_kquant_gemm_w4a8_pipe2()
+                && (!iq || e.has_kquant_iq_tile())
+                && stage.yq.len() >= chunk_rows * 144
+                && stage.xsums.len() >= chunk_rows * 4
+                && paddock_models::dev_var_os!("PADDOCK_Q4X_NO_KQ_TILE").is_none()
+            {
+                // Q2_K's per-16 min is built inside the tile; the per-32
+                // sums serve the k-quant mu formats only
+                let sums = needs && !iq;
+                let mut off = 0;
+                while off < batch {
+                    let rows = (batch - off).min(KQ_TILE_ROWS);
+                    e.quantize_q8_mmq_rows(x, off, &mut stage.yq, in_dim, rows)?;
+                    if sums {
+                        e.mmq_sums(&stage.yq, &mut stage.xsums, in_dim, rows)?;
+                    }
+                    e.kquant_gemm_w4a8_pipe2_rows(
+                        k,
+                        &stage.yq,
+                        sums.then_some(&stage.xsums),
+                        y,
+                        off,
+                        rows,
+                    )?;
+                    off += rows;
+                }
+                return Ok(());
+            }
             if batch == 1 {
                 // the qwen35 serving class (`kq_w4a8_b1`): int8 activations
                 // through the W4A8 GEMV, the exact-f32 GEMV stays the oracle

--- a/crates/paddock-engine/tests/gpu_kquant_parity.rs
+++ b/crates/paddock-engine/tests/gpu_kquant_parity.rs
@@ -3445,3 +3445,181 @@ fn iq_dense_gemv_bench() {
         );
     }
 }
+
+/// The >64-row W4A8 tile (`kquant_gemm_w4a8_pipe2`, slot 580) on dense
+/// i-quant planes: against the raw-bytes CPU dequant at 65 rows (the first
+/// width the tile serves, one tile column with pad) and against the dp4a
+/// lane - the same exact-int class off the same per-32 quantization - at
+/// 144 and 1024 rows (two tile columns, ragged; the prefill-chunk width).
+/// The v1 / pipe launchers forward the type to pipe2, so they are checked
+/// to agree bit for bit.
+#[test]
+fn iq_w4a8_tile_matches_reference() {
+    let Some(model) = common::model("QWEN35_IQ2_GGUF", common::QWEN35_9B_UD_IQ2) else {
+        return;
+    };
+    let Some(exec) = common::gpu() else {
+        return;
+    };
+    if !exec.has_kquant_iq() || !exec.has_kquant_iq_dense() || !exec.has_kquant_iq_tile() {
+        eprintln!("pack lacks the i-quant tile rung (slot 580) - skipping");
+        return;
+    }
+    let map = MappedGguf::open(&model).expect("open gguf");
+    let mut checked = 0usize;
+    // the 9B UD-IQ2_XXS file: IQ2_XXS qkv / gate / up, IQ3_XXS attn_gate,
+    // Q2_K / IQ2_S / IQ3_S down planes by layer, Q3_K token_embd
+    for name in [
+        "blk.0.attn_qkv.weight",
+        "blk.0.attn_gate.weight",
+        "blk.0.ffn_gate.weight",
+        "blk.0.ffn_down.weight",
+        "blk.1.ffn_down.weight",
+        "blk.18.ffn_down.weight",
+        "token_embd.weight",
+    ] {
+        // PADDOCK_TEST_PLANES=a,b narrows the walk (compute-sanitizer runs)
+        if let Ok(list) = std::env::var("PADDOCK_TEST_PLANES")
+            && !list.split(',').any(|p| p == name)
+        {
+            continue;
+        }
+        let Ok((info, raw)) = map.tensor_bytes(name) else {
+            continue;
+        };
+        let is_iq = matches!(
+            info.ggml_type,
+            GgmlType::Iq1S
+                | GgmlType::Iq1M
+                | GgmlType::Iq2Xxs
+                | GgmlType::Iq2Xs
+                | GgmlType::Iq2S
+                | GgmlType::Iq3Xxs
+                | GgmlType::Iq3S
+                | GgmlType::Iq4Nl
+                | GgmlType::Q2K
+                | GgmlType::Q3K
+        );
+        if !is_iq {
+            eprintln!("{name}: {:?}, not i-quant - skipped", info.ggml_type);
+            continue;
+        }
+        let w = exec.repack_kquant(&map, name).expect("repack");
+        let (in_dim, out_dim) = (w.dims[0], w.dims[1]);
+        let needs = w.ty == GgmlType::Q2K;
+        let n_chunks = in_dim.div_ceil(128);
+
+        // 65 rows against the CPU reference on the dequantized activations
+        // (planes up to 64M weights - the vocab-wide ones take the GPU checks)
+        if in_dim * out_dim <= 64 << 20 {
+            let batch = 65usize;
+            let mut deq = vec![0f32; in_dim * out_dim];
+            paddock_kernels::reference::iq::dequant_iq(w.ty.raw(), raw, &mut deq)
+                .expect("raw dequant");
+            let x = deterministic_input(batch * in_dim, 31);
+            let mut xdq = vec![0f32; batch * in_dim];
+            for r in 0..batch {
+                let (qq, ss) = cpu_quantize_q8(&x[r * in_dim..(r + 1) * in_dim]);
+                for i in 0..in_dim {
+                    xdq[r * in_dim + i] = qq[i] as f32 * ss[i / 32];
+                }
+            }
+            let mut yref = vec![0f32; batch * out_dim];
+            for r in 0..batch {
+                for o in 0..out_dim {
+                    let mut a = 0f64;
+                    for i in 0..in_dim {
+                        a += deq[o * in_dim + i] as f64 * xdq[r * in_dim + i] as f64;
+                    }
+                    yref[r * out_dim + o] = a as f32;
+                }
+            }
+            let d_x = exec.to_device(&x).expect("x");
+            let batch_pad = batch.div_ceil(128) * 128;
+            let mut d_yq = exec.alloc_u8(n_chunks * batch_pad * 144).expect("yq");
+            exec.quantize_q8_mmq(&d_x, &mut d_yq, in_dim, batch)
+                .expect("quantize");
+            let mut d_sums = exec.alloc(n_chunks * batch_pad * 4).expect("sums");
+            exec.mmq_sums(&d_yq, &mut d_sums, in_dim, batch)
+                .expect("sums");
+            let mut d_y = exec.alloc(out_dim * batch).expect("y");
+            exec.kquant_gemm_w4a8_pipe2(&w, &d_yq, needs.then_some(&d_sums), &mut d_y, batch)
+                .expect("pipe2");
+            let y = exec.to_host(&d_y).expect("y host");
+            let e = rel_err(&y, &yref);
+            eprintln!(
+                "{name} {:?} [{in_dim}->{out_dim}] b={batch}: pipe2 vs cpu {e:.2e}",
+                w.ty
+            );
+            if e > 2e-5 {
+                eprintln!("  ref   {:?}", &yref[..4]);
+                eprintln!("  pipe2 {:?}", &y[..4]);
+            }
+            assert!(
+                e < 2e-5,
+                "{name} b={batch}: pipe2 tile vs CPU reference ({e:.2e})"
+            );
+        }
+
+        // 144 / 1024 rows against the dp4a lane, and v1 / pipe forward to pipe2
+        for batch in [144usize, 1024] {
+            let x = deterministic_input(batch * in_dim, 37);
+            let d_x = exec.to_device(&x).expect("x");
+            let mut d_xq = exec.alloc_i8(batch * in_dim).expect("xq");
+            let mut d_xs = exec.alloc(batch * in_dim / 32).expect("xs");
+            exec.quantize_q8(&d_x, &mut d_xq, &mut d_xs, batch * in_dim)
+                .expect("quant");
+            let mut d_ssums = exec.alloc(batch * in_dim / 16).expect("ssums");
+            exec.q8_sums_strided(&d_xq, &mut d_ssums, in_dim, batch)
+                .expect("ssums");
+            let mut d_y0 = exec.alloc(out_dim * batch).expect("y0");
+            exec.kquant_gemm_dp4a(
+                &w,
+                &d_xq,
+                &d_xs,
+                needs.then_some(&d_ssums),
+                &mut d_y0,
+                batch,
+            )
+            .expect("dp4a");
+            let y_dp4a = exec.to_host(&d_y0).expect("h");
+
+            let batch_pad = batch.div_ceil(128) * 128;
+            let mut d_yq = exec.alloc_u8(n_chunks * batch_pad * 144).expect("yq");
+            exec.quantize_q8_mmq(&d_x, &mut d_yq, in_dim, batch)
+                .expect("quantize");
+            let mut d_sums = exec.alloc(n_chunks * batch_pad * 4).expect("sums");
+            exec.mmq_sums(&d_yq, &mut d_sums, in_dim, batch)
+                .expect("sums");
+            let mut d_y = exec.alloc(out_dim * batch).expect("y");
+            exec.kquant_gemm_w4a8_pipe2(&w, &d_yq, needs.then_some(&d_sums), &mut d_y, batch)
+                .expect("pipe2");
+            let y = exec.to_host(&d_y).expect("y host");
+            let e = rel_err(&y, &y_dp4a);
+            eprintln!("{name} {:?} b={batch}: pipe2 vs dp4a {e:.2e}", w.ty);
+            assert!(
+                e < 1e-5,
+                "{name} b={batch}: pipe2 tile vs dp4a lane ({e:.2e})"
+            );
+
+            let mut d_y1 = exec.alloc(out_dim * batch).expect("y1");
+            exec.kquant_gemm_w4a8(&w, &d_yq, needs.then_some(&d_sums), &mut d_y1, batch)
+                .expect("w4a8 v1 -> pipe2");
+            let y1 = exec.to_host(&d_y1).expect("h");
+            assert!(
+                y1 == y,
+                "{name} b={batch}: the v1 launcher did not forward to pipe2"
+            );
+            let mut d_y2 = exec.alloc(out_dim * batch).expect("y2");
+            exec.kquant_gemm_w4a8_pipe(&w, &d_yq, needs.then_some(&d_sums), &mut d_y2, batch)
+                .expect("w4a8 pipe -> pipe2");
+            let y2 = exec.to_host(&d_y2).expect("h");
+            assert!(
+                y2 == y,
+                "{name} b={batch}: the pipe launcher did not forward to pipe2"
+            );
+        }
+        checked += 1;
+    }
+    assert!(checked > 0, "no i-quant plane in the file");
+}

--- a/crates/paddock-engine/tests/gpu_qwen35_prefill_vs_serial.rs
+++ b/crates/paddock-engine/tests/gpu_qwen35_prefill_vs_serial.rs
@@ -111,3 +111,52 @@ fn batched_prefill_matches_serial_step() {
         "batched prefill and serial step disagree by {worst_lp:.4} nats on the winner's logprob"
     );
 }
+
+/// Batched prefill rate on the oracle file: `prefill` over a 2048-token
+/// prompt (the chunk width the serving path feeds the GEMM lanes), best of
+/// three after a warm-up. Heavy + ignored:
+/// `cargo test ... prefill_rate_bench -- --ignored --nocapture`.
+/// `QWEN35_ORACLE_LONG` sets the token count.
+#[test]
+#[ignore]
+fn prefill_rate_bench() {
+    if !common::heavy() {
+        return;
+    }
+    let Some(path) = common::model("QWEN35_ORACLE_GGUF", common::QWEN35_9B_UD_IQ2) else {
+        return;
+    };
+    let Some(exec) = common::gpu_arc() else {
+        return;
+    };
+    let map = MappedGguf::open(&path).expect("open gguf");
+    let tok = GgufTokenizer::from_gguf(map.gguf()).expect("tokenizer");
+    let n = std::env::var("QWEN35_ORACLE_LONG")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(2048usize);
+    let mut m = GpuQwen35::load(exec, &map, n.max(2048)).expect("load");
+    let unit = tok.encode(LONG_UNIT).expect("encode");
+    let prompt: Vec<u32> = unit.iter().cycle().take(n).copied().collect();
+    let mut best = f64::MAX;
+    for i in 0..4 {
+        m.reset();
+        let t = std::time::Instant::now();
+        let logits = m.prefill(&prompt).expect("prefill");
+        let dt = t.elapsed().as_secs_f64();
+        if i > 0 {
+            best = best.min(dt);
+        }
+        eprintln!(
+            "prefill {n} tokens: {:.1} ms ({:.0} tok/s), top-1 {}",
+            dt * 1e3,
+            n as f64 / dt,
+            argmax(&logits)
+        );
+    }
+    eprintln!(
+        "best: {:.1} ms = {:.0} tok/s over {n} tokens",
+        best * 1e3,
+        n as f64 / best
+    );
+}

--- a/crates/paddock-engine/tests/gpu_qwen4exp_gguf.rs
+++ b/crates/paddock-engine/tests/gpu_qwen4exp_gguf.rs
@@ -528,3 +528,116 @@ fn gguf_teacher_forced_agreement() {
         "llama's chosen token fell to rank {worst_rank} (> top-5)"
     );
 }
+
+/// The dense k-quant planes above 64 rows: the W4A8 tile (`kq_matmul`'s
+/// pipe2 route) against the dp4a lane on the same per-32 quantized
+/// activations - the same exact-int class, so the bar is tight. 163 rows
+/// is one tile column plus a ragged second; the file's Q5_K / Q6_K planes.
+#[test]
+fn gguf_kq_dense_tile_matches_dp4a() {
+    let Some(path) = common::model("QWEN38FN_GGUF", &[]) else {
+        common::missing("QWEN38FN_GGUF");
+        return;
+    };
+    let Some(exec) = common::gpu_arc() else {
+        return;
+    };
+    if !exec.has_kquant_gemm_w4a8_pipe2() {
+        eprintln!("pack lacks kquant_gemm_w4a8_pipe2 - skipping");
+        return;
+    }
+    let map = MappedGguf::open(&path).expect("open gguf");
+    let rel = |a: &[f32], b: &[f32]| {
+        let (mut n, mut d) = (0f64, 0f64);
+        for (x, y) in a.iter().zip(b) {
+            n += ((x - y) as f64).powi(2);
+            d += (*y as f64).powi(2);
+        }
+        (n / d.max(1e-30)).sqrt()
+    };
+    let batch = 163usize;
+    for name in [
+        "blk.0.ssm_out.weight",
+        "blk.0.attn_qkv.weight",
+        "blk.3.attn_output.weight",
+        "blk.0.ffn_gate_shexp.weight",
+    ] {
+        let (info, _) = map.tensor_bytes(name).expect("tensor");
+        let (in_dim, out_dim) = (info.dims[0] as usize, info.dims[1] as usize);
+        let w = exec.load_quantw(&map, name).expect("load_quantw");
+        let paddock_engine::gpu::QuantW::Kq(k) = &w else {
+            panic!("{name}: not k-quant");
+        };
+        let needs = matches!(
+            k.ty,
+            GgmlType::Q4K | GgmlType::Q5K | GgmlType::Q4_0 | GgmlType::Q2K
+        );
+        let x: Vec<f32> = (0..batch * in_dim)
+            .map(|i| (((i as u64 * 2654435761) >> 13) % 2001) as f32 / 1000.0 - 1.0)
+            .collect();
+        let d_x = exec.to_device(&x).expect("x");
+        let mut d_xq = exec.alloc_i8(batch * in_dim).expect("xq");
+        let mut d_xs = exec.alloc(batch * in_dim / 32).expect("xs");
+        exec.quantize_q8(&d_x, &mut d_xq, &mut d_xs, batch * in_dim)
+            .expect("quant");
+        let mut d_sums = exec.alloc(batch * in_dim / 16).expect("sums");
+        exec.q8_sums_strided(&d_xq, &mut d_sums, in_dim, batch)
+            .expect("sums");
+        let mut d_y = exec.alloc(batch * out_dim).expect("y");
+        exec.kquant_gemm_dp4a(k, &d_xq, &d_xs, needs.then_some(&d_sums), &mut d_y, batch)
+            .expect("dp4a");
+        let y_dp4a = exec.to_host(&d_y).expect("h");
+        let n_chunks = in_dim.div_ceil(128);
+        let batch_pad = batch.div_ceil(128) * 128;
+        let mut d_yq = exec.alloc_u8(n_chunks * batch_pad * 144).expect("yq");
+        exec.quantize_q8_mmq(&d_x, &mut d_yq, in_dim, batch)
+            .expect("quantize mmq");
+        let mut d_msums = exec.alloc(n_chunks * batch_pad * 4).expect("msums");
+        exec.mmq_sums(&d_yq, &mut d_msums, in_dim, batch)
+            .expect("mmq sums");
+        let mut d_yt = exec.alloc(batch * out_dim).expect("yt");
+        exec.kquant_gemm_w4a8_pipe2(k, &d_yq, needs.then_some(&d_msums), &mut d_yt, batch)
+            .expect("pipe2");
+        let y_tile = exec.to_host(&d_yt).expect("h");
+        let e = rel(&y_tile, &y_dp4a);
+        eprintln!(
+            "{name} {:?} [{in_dim}->{out_dim}] b={batch}: tile vs dp4a {e:.2e}",
+            k.ty
+        );
+        assert!(
+            e < 1e-5,
+            "{name}: the W4A8 tile diverged from the dp4a lane ({e:.2e})"
+        );
+
+        // the same rows through kq_matmul's chunk walk: 100-row chunks off a
+        // chunk-sized scratch, stitched by the row-offset launchers
+        let chunk = 100usize;
+        let cpad = chunk.div_ceil(128) * 128;
+        let mut c_yq = exec.alloc_u8(n_chunks * cpad * 144).expect("cyq");
+        let mut c_sums = exec.alloc(n_chunks * cpad * 4).expect("csums");
+        let mut d_ys = exec.alloc(batch * out_dim).expect("ys");
+        let mut off = 0;
+        while off < batch {
+            let rows = (batch - off).min(chunk);
+            exec.quantize_q8_mmq_rows(&d_x, off, &mut c_yq, in_dim, rows)
+                .expect("quantize rows");
+            exec.mmq_sums(&c_yq, &mut c_sums, in_dim, rows)
+                .expect("sums rows");
+            exec.kquant_gemm_w4a8_pipe2_rows(
+                k,
+                &c_yq,
+                needs.then_some(&c_sums),
+                &mut d_ys,
+                off,
+                rows,
+            )
+            .expect("pipe2 rows");
+            off += rows;
+        }
+        let y_chunked = exec.to_host(&d_ys).expect("h");
+        assert!(
+            y_chunked == y_tile,
+            "{name}: the chunked walk differs from the one-shot tile"
+        );
+    }
+}

--- a/crates/paddock-kernels/src/abi.rs
+++ b/crates/paddock-kernels/src/abi.rs
@@ -6154,6 +6154,11 @@ pub struct KernelTableV1 {
     /// converter writes); `q4x_gdn_split_widen` keeps the raw-safetensors
     /// interleave map. Same signature.
     pub q4x_gdn_split_widen_tiled: Option<Q4xGdnSplitWidenFn>,
+    /// 580: capability marker - `kquant_gemm_w4a8_pipe2` (and the v1 / pipe
+    /// launchers, which forward to it) serve the i-quant family + Q2_K /
+    /// Q3_K / IQ4_NL: the >64-row prefill tile for dense i-quant planes.
+    /// Without it such a plane stays on the per-token dp4a walk.
+    pub kquant_iq_tile: Option<unsafe extern "C" fn() -> i32>,
 }
 
 /// MoE expert-offload cache resolve (see `KernelTableV1::moe_cache_resolve`).
@@ -6531,7 +6536,7 @@ pub type AddRmsnormQ8XnFn = unsafe extern "C" fn(
 /// the copy to the smaller of declared and expected, so an old pack against a
 /// new engine (or the reverse) reads missing entries as None rather than a
 /// shifted slot.
-pub const KERNEL_TABLE_SLOTS: usize = 565;
+pub const KERNEL_TABLE_SLOTS: usize = 566;
 
 const _: () = assert!(
     core::mem::size_of::<KernelTableV1>() == 8 + KERNEL_TABLE_SLOTS * 8,

--- a/packs/cuda/src/abi.cuh
+++ b/packs/cuda/src/abi.cuh
@@ -2815,6 +2815,10 @@ struct KernelTableV1 {
     // q4x_gdn_split_widen (slot for the interleave map).
     int (*q4x_gdn_split_widen_tiled)(const void*, void*, void*, void*, uint32_t,
                                      uint32_t, uint32_t, uint32_t, uint32_t, void*);
+    // 580: kquant_iq_tile - capability marker: kquant_gemm_w4a8_pipe2 (and
+    // the v1 / pipe launchers, which forward) serve the i-quant family +
+    // Q2_K / Q3_K / IQ4_NL - the >64-row prefill tile for dense i-quant planes.
+    int (*kquant_iq_tile)(void);
 };
 
 } // extern "C"

--- a/packs/cuda/src/exports.cuh
+++ b/packs/cuda/src/exports.cuh
@@ -1487,6 +1487,7 @@ static const KernelTableV1 PD_KERNELS = {
     pd_kquant_iq,
     pd_kquant_iq_dense,
     pd_q4x_gdn_split_widen_tiled,
+    pd_kquant_iq_tile,
 };
 
 PD_EXPORT const PackInfo* paddock_pack_info(void) {

--- a/packs/cuda/src/quant/iquant.cuh
+++ b/packs/cuda/src/quant/iquant.cuh
@@ -54,7 +54,7 @@
 
 #define PD_IQ1S_DELTA 0.125f
 
-__host__ __device__ __forceinline__ bool pd_kq_valid_iq(uint32_t dt) {
+__host__ __device__ constexpr bool pd_kq_valid_iq(uint32_t dt) {
     return dt == PD_KQ_IQ2XXS || dt == PD_KQ_IQ2XS || dt == PD_KQ_IQ2S ||
            dt == PD_KQ_IQ3XXS || dt == PD_KQ_IQ3S || dt == PD_KQ_IQ1S ||
            dt == PD_KQ_IQ1M || dt == PD_KQ_IQ4NL_ID ||
@@ -82,7 +82,7 @@ __host__ __device__ __forceinline__ uint32_t pd_iq_srcb(uint32_t dt) {
 // to 4. The k-quant family keeps its fixed 24-byte record (PD_KQ_SCB); the
 // slimmer i-quant records are what let a 1-2 bit expert set stay near its
 // raw size in host-mapped memory (a 24-byte record is +48% on IQ1_S).
-__host__ __device__ __forceinline__ uint32_t pd_iq_scb(uint32_t dt) {
+__host__ __device__ constexpr uint32_t pd_iq_scb(uint32_t dt) {
     switch (dt) {
         case PD_KQ_IQ2XXS: return 4u;   // d
         case PD_KQ_IQ2XS: return 12u;   // d + scales[8]
@@ -98,7 +98,7 @@ __host__ __device__ __forceinline__ uint32_t pd_iq_scb(uint32_t dt) {
 }
 
 // repacked data bytes per super-block (16-byte multiples)
-__host__ __device__ __forceinline__ uint32_t pd_iq_datab(uint32_t dt) {
+__host__ __device__ constexpr uint32_t pd_iq_datab(uint32_t dt) {
     switch (dt) {
         case PD_KQ_IQ2XXS: return 64u;
         case PD_KQ_IQ2XS: return 64u;

--- a/packs/cuda/src/quant/iquant_dense.cuh
+++ b/packs/cuda/src/quant/iquant_dense.cuh
@@ -121,7 +121,11 @@ __global__ void __launch_bounds__(256) pd_iqd_dp4a_kernel(
         const int8_t* __restrict__ xq, const float* __restrict__ xs,
         const float* __restrict__ xsums, float* __restrict__ y,
         uint32_t in_dim, uint32_t out_dim, uint32_t batch, uint32_t dtype) {
-    const uint32_t task = (blockIdx.x * blockDim.x + threadIdx.x) >> 5;
+    // 8 warps per block, block-major: blockIdx.x * 8 stays in 32 bits for
+    // every (out_dim, batch) the launcher admits, where the thread-linear
+    // form (blockIdx.x * 256 + tid) overflowed past 134M outputs - the
+    // vocab-wide head at batch 1024 wrote its first 88% of rows only.
+    const uint32_t task = blockIdx.x * 8u + (threadIdx.x >> 5u);
     const uint32_t lane = threadIdx.x & 31u;
     if (task >= out_dim * batch) return;
     const uint32_t o = task / batch, b = task - o * batch;
@@ -505,8 +509,9 @@ int pd_kq_iq_dense_dp4a(const void* data, const void* scales, const void* xq,
             return pd_launch_status();
         }
     }
+    if ((size_t)out_dim * batch > 0xFFFFFFFFull) return cudaErrorInvalidValue;
     const uint32_t tasks = out_dim * batch;
-    const uint32_t blocks = (tasks * 32u + 255u) / 256u;
+    const uint32_t blocks = (tasks + 7u) / 8u;  // 8 warps (tasks) per block
     pd_iqd_dp4a_kernel<<<blocks, 256, 0, (cudaStream_t)stream>>>(
         (const uint8_t*)data, (const uint8_t*)scales, (const int8_t*)xq, (const float*)xs,
         (const float*)xsums, (float*)y, in_dim, out_dim, batch, dtype);

--- a/packs/cuda/src/quant/kquant_w4a8.cuh
+++ b/packs/cuda/src/quant/kquant_w4a8.cuh
@@ -650,11 +650,22 @@ int pd_kquant_gemm_dp4a(const void* data, const void* scales, const void* xq,
 }
 
 PD_EXPORT
+int pd_kquant_gemm_w4a8_pipe2(const void* data, const void* scales, const void* yq,
+                              const void* xsums, void* y, uint32_t in_dim,
+                              uint32_t out_dim, uint32_t batch, uint32_t dtype,
+                              void* stream);
+
+PD_EXPORT
 int pd_kquant_gemm_w4a8(const void* data, const void* scales, const void* yq,
                         const void* xsums, void* y, uint32_t in_dim,
                         uint32_t out_dim, uint32_t batch, uint32_t dtype,
                         void* stream) {
     if (out_dim == 0 || batch == 0) return 0;
+    // the i-quant family has one tile rung, pipe2 (its raw ring is sized per
+    // type and its tile builds through the shared window unpack)
+    if (pd_kq_valid_iq(dtype))
+        return pd_kquant_gemm_w4a8_pipe2(data, scales, yq, xsums, y, in_dim, out_dim,
+                                         batch, dtype, stream);
     if ((in_dim & 255u) != 0u) return cudaErrorInvalidValue;
     if (!pd_kq_valid(dtype)) return cudaErrorInvalidValue;
     const bool mu = pd_kq_has_mu(dtype);
@@ -720,6 +731,16 @@ __device__ __forceinline__ void pd_kq_cpa8p(void* smem, const void* gmem, bool o
     const unsigned sm = (unsigned)__cvta_generic_to_shared(smem);
     asm volatile("cp.async.ca.shared.global [%0], [%1], 8, %2;" ::"r"(sm), "l"(gmem),
                  "r"(ok ? 8u : 0u));
+#endif
+}
+
+// 4-byte predicated cp.async: the i-quant scale records (quant/iquant.cuh
+// pd_iq_scb) are 4-24 B and only 4-B aligned. src-size 0 zero-fills.
+__device__ __forceinline__ void pd_kq_cpa4p(void* smem, const void* gmem, bool ok) {
+#if PD_MMA_OK
+    const unsigned sm = (unsigned)__cvta_generic_to_shared(smem);
+    asm volatile("cp.async.ca.shared.global [%0], [%1], 4, %2;" ::"r"(sm), "l"(gmem),
+                 "r"(ok ? 4u : 0u));
 #endif
 }
 
@@ -2761,6 +2782,9 @@ int pd_kquant_gemm_w4a8_pipe(const void* data, const void* scales, const void* y
                              uint32_t out_dim, uint32_t batch, uint32_t dtype,
                              void* stream) {
     if (out_dim == 0 || batch == 0) return 0;
+    if (pd_kq_valid_iq(dtype))
+        return pd_kquant_gemm_w4a8_pipe2(data, scales, yq, xsums, y, in_dim, out_dim,
+                                         batch, dtype, stream);
     if ((in_dim & 255u) != 0u) return cudaErrorInvalidValue;
     if (!pd_kq_valid(dtype)) return cudaErrorInvalidValue;
     const bool mu = pd_kq_has_mu(dtype);
@@ -2829,7 +2853,27 @@ int pd_kquant_gemm_w4a8_pipe(const void* data, const void* scales, const void* y
 // loads into the other buffer, commit, wait_group(1) (guarantees the OLDER
 // of the two outstanding commit groups - this kt's own data - has landed),
 // consume; wait_group(0) drains the last chunk once there's no next one.
+// The i-quant family + Q2_K / Q3_K / IQ4_NL ride the same kernel: the raw
+// ring is sized per type (quant/iquant.cuh pd_iq_datab / pd_iq_scb), the
+// half tile_x is built through the shared 16-weight window unpack
+// (pd_iq_win_unpack_t) into 48-int rows - 32 payload words in k order, the 8
+// windows' f32 scales at [32, 40) and, for Q2_K, their per-16 min at
+// [40, 48) - and consumed on the Q6_K (per-16 scale, m16n8k16) path. Q2_K's
+// min term multiplies per-16 activation sums the kernel builds itself from
+// the mmq tile (the launcher's per-32 xsums do not serve a per-16 min), 8
+// f32 per column in tile_s. The format's codebook is staged in shared after
+// tile_s (2-16 KB). Every type stays under sm_120's 101,376 B single-block
+// cap: IQ4_NL is the largest at 79,872 B, IQ1_S/M carry the 16 KB grid at
+// 72,704 B.
 __host__ __device__ __forceinline__ uint32_t pd_kwh2_smem_bytes(uint32_t dt) {
+    if (pd_kq_valid_iq(dt)) {
+        const uint32_t raw_w2 = 2u * 128u * pd_iq_datab(dt);
+        const uint32_t raw_r2 = 2u * 128u * pd_iq_scb(dt);
+        const uint32_t tile_x_sz = 128u * 48u * 4u;
+        const uint32_t tile_y_sz = 128u * PD_MMQ_YK * 4u;
+        const uint32_t tile_s_sz = dt == PD_KQ_Q2K_ID ? 128u * 8u * 4u : 16u;
+        return raw_w2 + raw_r2 + tile_x_sz + tile_y_sz + tile_s_sz + pd_iq_tabs_bytes(dt);
+    }
     const uint32_t datab = pd_kq_datab(dt);
     const bool mu = pd_kq_has_mu(dt);
     const uint32_t raw_w2 = 2u * 128u * datab;
@@ -2846,13 +2890,20 @@ __global__ void __launch_bounds__(256, 1) pd_kquant_w4a8_pipe2_kernel(
         const uint8_t* __restrict__ yq, const float* __restrict__ xsums,
         float* __restrict__ y, uint32_t in_dim, uint32_t out_dim, uint32_t batch) {
 #if PD_MMA_OK
+    constexpr bool IQ = pd_kq_valid_iq(DT);
     constexpr bool MU = (DT == PD_KQ_Q4K || DT == PD_KQ_Q5K || DT == PD_KQ_Q40);
-    constexpr bool K16 = (DT == PD_KQ_Q6K);
-    constexpr uint32_t DATAB = DT == PD_KQ_Q6K ? PD_KQ6_DATA
+    constexpr bool MU16 = (DT == PD_KQ_Q2K_ID);  // per-16 min (the window unpack's g)
+    constexpr bool K16 = (DT == PD_KQ_Q6K) || IQ;
+    constexpr uint32_t DATAB = IQ ? pd_iq_datab(DT)
+                             : DT == PD_KQ_Q6K ? PD_KQ6_DATA
                              : DT == PD_KQ_Q5K ? PD_KQ5_DATA : PD_KQ4_DATA;
+    constexpr uint32_t SCB = IQ ? pd_iq_scb(DT) : PD_KQ_SCB;
     constexpr uint32_t RAW_W = 128u * DATAB;
-    constexpr uint32_t RAW_R = 128u * PD_KQ_SCB;
-    constexpr uint32_t KWH_XK = 40u;  // half-superblock tile_x row: 32 payload + 8 scale/mu
+    constexpr uint32_t RAW_R = 128u * SCB;
+    // half-superblock tile_x row: 32 payload + 8 scale/mu (k-quant) or + 8
+    // window scales + 8 window mins (i-quant)
+    constexpr uint32_t KWH_XK = IQ ? 48u : 40u;
+    constexpr uint32_t TS_F = MU ? 128u * 4u : MU16 ? 128u * 8u : 4u;  // tile_s floats
 
     const uint32_t tid = threadIdx.x;
     const uint32_t lane = tid & 31u, warp = tid >> 5u;
@@ -2880,6 +2931,11 @@ __global__ void __launch_bounds__(256, 1) pd_kquant_w4a8_pipe2_kernel(
     int* const tile_x = (int*)(raw_r1 + RAW_R);
     int* const tile_y = tile_x + 128 * KWH_XK;
     float* const tile_s = (float*)(tile_y + 128 * PD_MMQ_YK);
+    PdIqTabs tabs = {nullptr, nullptr};
+    if (IQ) {
+        tabs = pd_iq_tabs_stage(DT, (uint8_t*)(tile_s + TS_F));
+        __syncthreads();
+    }
     float acc[16][4] = {};
 
     // Same byte layout as pd_kquant_w4a8_pipe_kernel's stage(), parameterized
@@ -2895,12 +2951,23 @@ __global__ void __launch_bounds__(256, 1) pd_kquant_w4a8_pipe2_kernel(
                           data + ((size_t)(row_base + row) * n_super + kt) * DATAB
                               + c * 16u, ok);
         }
-        for (uint32_t i = tid; i < 128u * 3u; i += 256u) {
-            const uint32_t row = i / 3u, c = i % 3u;
-            const bool ok = (row_base + row) < out_dim;
-            pd_kq_cpa8p(rr + row * PD_KQ_SCB + c * 8u,
-                        scales + ((size_t)(row_base + row) * n_super + kt) *
-                            PD_KQ_SCB + c * 8u, ok);
+        if (IQ) {
+            constexpr uint32_t RCH = SCB / 4u;
+            for (uint32_t i = tid; i < 128u * RCH; i += 256u) {
+                const uint32_t row = i / RCH, c = i % RCH;
+                const bool ok = (row_base + row) < out_dim;
+                pd_kq_cpa4p(rr + row * SCB + c * 4u,
+                            scales + ((size_t)(row_base + row) * n_super + kt) * SCB
+                                + c * 4u, ok);
+            }
+        } else {
+            for (uint32_t i = tid; i < 128u * 3u; i += 256u) {
+                const uint32_t row = i / 3u, c = i % 3u;
+                const bool ok = (row_base + row) < out_dim;
+                pd_kq_cpa8p(rr + row * PD_KQ_SCB + c * 8u,
+                            scales + ((size_t)(row_base + row) * n_super + kt) *
+                                PD_KQ_SCB + c * 8u, ok);
+            }
         }
     };
 
@@ -2920,6 +2987,22 @@ __global__ void __launch_bounds__(256, 1) pd_kquant_w4a8_pipe2_kernel(
                 tile_s[l] = xsums[((size_t)chunk * batch_pad + col_base) * 4u + l];
             }
         }
+        if (MU16) {
+            // per-16 activation sums x their per-32 scale, straight off the
+            // mmq tile: 128 columns x 8 windows, four per thread
+            #pragma unroll
+            for (uint32_t it = 0; it < 4u; ++it) {
+                const uint32_t i = it * 256u + tid;
+                const uint32_t col = i >> 3u, w = i & 7u;
+                const int* pw = by + col * PD_MMQ_YK + 4u + 4u * w;
+                int sm = __dp4a(pw[0], 0x01010101, 0);
+                sm = __dp4a(pw[1], 0x01010101, sm);
+                sm = __dp4a(pw[2], 0x01010101, sm);
+                sm = __dp4a(pw[3], 0x01010101, sm);
+                const float scl = ((const float*)by)[col * PD_MMQ_YK + (w >> 1u)];
+                tile_s[col * 8u + w] = scl * (float)sm;
+            }
+        }
     };
 
     // Build the HALF-width tile_x for super `kt`'s `half` (0 or 1) out of
@@ -2933,6 +3016,30 @@ __global__ void __launch_bounds__(256, 1) pd_kquant_w4a8_pipe2_kernel(
     auto build_half = [&](uint32_t half, uint32_t buf) {
         unsigned char* const rw = buf ? raw_w1 : raw_w0;
         unsigned char* const rr = buf ? raw_r1 : raw_r0;
+        if (IQ) {
+            // 128 rows x 8 windows of 16 through the shared window unpack:
+            // the 4 packed-s8 words land in k order at [wl*4, wl*4+4), the
+            // window's f32 scale at [32 + wl], Q2_K's per-16 min at [40 + wl].
+            // Dead rows (zero-filled raw) write zeros.
+            #pragma unroll
+            for (uint32_t it = 0; it < 4u; ++it) {
+                const uint32_t i = it * 256u + tid;
+                const uint32_t row = i >> 3u, wl = i & 7u;
+                const bool live = (row_base + row) < out_dim;
+                int wq[4] = {0, 0, 0, 0};
+                float f = 0.0f, gm = 0.0f;
+                if (live)
+                    pd_iq_win_unpack_t(DT, rw + row * DATAB, rr + row * SCB, half * 8u + wl,
+                                       wq, &f, &gm, tabs);
+                int* const xr = tile_x + row * KWH_XK;
+                *reinterpret_cast<int4*>(xr + wl * 4u) = make_int4(wq[0], wq[1], wq[2], wq[3]);
+                reinterpret_cast<float*>(xr)[32u + wl] = f;
+                if (MU16) reinterpret_cast<float*>(xr)[40u + wl] = gm;
+            }
+            __syncthreads();
+            return;
+        }
+        if (IQ) return;  // (the k-quant build below is not instantiated for IQ)
         #pragma unroll
         for (uint32_t it = 0; it < 2u; ++it) {  // 128 rows * 4 ci = 512 = 2*256
             const uint32_t i = it * 256u + tid;
@@ -3077,6 +3184,7 @@ __global__ void __launch_bounds__(256, 1) pd_kquant_w4a8_pipe2_kernel(
         float dA[2][2][4];
         float muA[2][2][4];
         float sA[2][2][8];
+        float mA16[2][2][8];
         #pragma unroll
         for (uint32_t n = 0; n < 2u; ++n) {
             const uint32_t r0 = (i0 + n * 16u + g) * KWH_XK;
@@ -3094,6 +3202,12 @@ __global__ void __launch_bounds__(256, 1) pd_kquant_w4a8_pipe2_kernel(
                     sA[n][0][2u * kk + 1u] = ((const float*)tile_x)[r0 + so + 1u];
                     sA[n][1][2u * kk] = ((const float*)tile_x)[r8 + so];
                     sA[n][1][2u * kk + 1u] = ((const float*)tile_x)[r8 + so + 1u];
+                    if (MU16) {
+                        mA16[n][0][2u * kk] = ((const float*)tile_x)[r0 + so + 8u];
+                        mA16[n][0][2u * kk + 1u] = ((const float*)tile_x)[r0 + so + 9u];
+                        mA16[n][1][2u * kk] = ((const float*)tile_x)[r8 + so + 8u];
+                        mA16[n][1][2u * kk + 1u] = ((const float*)tile_x)[r8 + so + 9u];
+                    }
                 } else {
                     dA[n][0][kk] = ((const float*)tile_x)[r0 + 32u + kk];
                     dA[n][1][kk] = ((const float*)tile_x)[r8 + 32u + kk];
@@ -3119,6 +3233,13 @@ __global__ void __launch_bounds__(256, 1) pd_kquant_w4a8_pipe2_kernel(
                     S0 = tile_s[(jc + 2u * t) * 4u + kk];
                     S1 = tile_s[(jc + 2u * t + 1u) * 4u + kk];
                 }
+                float S0a = 0.0f, S0b = 0.0f, S1a = 0.0f, S1b = 0.0f;
+                if (MU16) {
+                    S0a = tile_s[(jc + 2u * t) * 8u + 2u * kk];
+                    S0b = tile_s[(jc + 2u * t) * 8u + 2u * kk + 1u];
+                    S1a = tile_s[(jc + 2u * t + 1u) * 8u + 2u * kk];
+                    S1b = tile_s[(jc + 2u * t + 1u) * 8u + 2u * kk + 1u];
+                }
                 #pragma unroll
                 for (uint32_t n = 0; n < 2u; ++n) {
                     if (K16) {
@@ -3138,6 +3259,14 @@ __global__ void __launch_bounds__(256, 1) pd_kquant_w4a8_pipe2_kernel(
                         acc[(j0 >> 3) + n][1] += dB1 * (sa0 * (float)d1 + sa1 * (float)e1);
                         acc[(j0 >> 3) + n][2] += dB0 * (sb0_ * (float)d2 + sb1_ * (float)e2);
                         acc[(j0 >> 3) + n][3] += dB1 * (sb0_ * (float)d3 + sb1_ * (float)e3);
+                        if (MU16) {
+                            const float ma0 = mA16[n][0][2u * kk], mb0 = mA16[n][0][2u * kk + 1u];
+                            const float ma8 = mA16[n][1][2u * kk], mb8 = mA16[n][1][2u * kk + 1u];
+                            acc[(j0 >> 3) + n][0] += ma0 * S0a + mb0 * S0b;
+                            acc[(j0 >> 3) + n][1] += ma0 * S1a + mb0 * S1b;
+                            acc[(j0 >> 3) + n][2] += ma8 * S0a + mb8 * S0b;
+                            acc[(j0 >> 3) + n][3] += ma8 * S1a + mb8 * S1b;
+                        }
                     } else {
                         int d0 = 0, d1 = 0, d2 = 0, d3 = 0;
                         asm("mma.sync.aligned.m16n8k32.row.col.s32.s8.s8.s32 "
@@ -3217,8 +3346,10 @@ int pd_kquant_gemm_w4a8_pipe2(const void* data, const void* scales, const void* 
                               void* stream) {
     if (out_dim == 0 || batch == 0) return 0;
     if ((in_dim & 255u) != 0u) return cudaErrorInvalidValue;
-    if (!pd_kq_valid(dtype)) return cudaErrorInvalidValue;
-    const bool mu = pd_kq_has_mu(dtype);
+    if (!pd_kq_valid(dtype) && !pd_kq_valid_iq(dtype)) return cudaErrorInvalidValue;
+    // Q2_K's per-16 min term is built in-kernel off the mmq tile; the
+    // per-32 xsums are neither needed nor read for the i-quant family
+    const bool mu = pd_kq_has_mu(dtype) && !pd_kq_valid_iq(dtype);
     if (mu && xsums == nullptr) return cudaErrorInvalidValue;
     const uint32_t batch_pad = (batch + 127u) & ~127u;
     const uint32_t ntiles = ((out_dim + 127u) / 128u) * (batch_pad >> 7u);
@@ -3240,8 +3371,23 @@ int pd_kquant_gemm_w4a8_pipe2(const void* data, const void* scales, const void* 
         case PD_KQ_Q4K: PD_KWH2_LAUNCH(PD_KQ_Q4K); break;
         case PD_KQ_Q5K: PD_KWH2_LAUNCH(PD_KQ_Q5K); break;
         case PD_KQ_Q6K: PD_KWH2_LAUNCH(PD_KQ_Q6K); break;
+        case PD_KQ_IQ2XXS: PD_KWH2_LAUNCH(PD_KQ_IQ2XXS); break;
+        case PD_KQ_IQ2XS: PD_KWH2_LAUNCH(PD_KQ_IQ2XS); break;
+        case PD_KQ_IQ2S: PD_KWH2_LAUNCH(PD_KQ_IQ2S); break;
+        case PD_KQ_IQ3XXS: PD_KWH2_LAUNCH(PD_KQ_IQ3XXS); break;
+        case PD_KQ_IQ3S: PD_KWH2_LAUNCH(PD_KQ_IQ3S); break;
+        case PD_KQ_IQ1S: PD_KWH2_LAUNCH(PD_KQ_IQ1S); break;
+        case PD_KQ_IQ1M: PD_KWH2_LAUNCH(PD_KQ_IQ1M); break;
+        case PD_KQ_IQ4NL_ID: PD_KWH2_LAUNCH(PD_KQ_IQ4NL_ID); break;
+        case PD_KQ_Q2K_ID: PD_KWH2_LAUNCH(PD_KQ_Q2K_ID); break;
+        case PD_KQ_Q3K_ID: PD_KWH2_LAUNCH(PD_KQ_Q3K_ID); break;
         default: PD_KWH2_LAUNCH(PD_KQ_IQ4XS); break;
     }
     #undef PD_KWH2_LAUNCH
     return pd_launch_status();
 }
+
+// Capability marker (slot 580): the >64-row W4A8 tile GEMM serves the
+// i-quant family + Q2_K / Q3_K / IQ4_NL - the engine's prefill can keep a
+// dense i-quant plane on the tile rung instead of the per-token dp4a walk.
+PD_EXPORT int pd_kquant_iq_tile(void) { return 0; }


### PR DESCRIPTION
## What

The open item from e05d80b: dense i-quant planes above 64 rows took the dp4a walk, re-reading the plane once per token. Three commits on top of main (bd23391):

1. `cuda+engine: dense i-quant planes ride the >64-row W4A8 tile GEMM (pipe2)` - `pd_kquant_w4a8_pipe2_kernel` instantiates for the i-quant family + Q2_K / Q3_K / IQ4_NL. The raw ring is sized per type (`pd_iq_datab` / `pd_iq_scb`, 4-byte cp.async for the short records) and `build_half` fills the half tile_x through the shared window unpack (`pd_iq_win_unpack_t`): the 4 packed-s8 words in k order, the 8 windows' f32 scales at [32, 40), consumed on the Q6_K per-16 path (m16n8k16). Q2_K's per-16 min (the unpack's `g`) lands at [40, 48) and multiplies per-16 activation sums the kernel builds off the mmq tile in `load_act` (the per-32 `xsums` cannot serve a per-16 min). The codebook is staged in shared after tile_s. Every type stays under sm_120's 101,376 B single-block cap (IQ4_NL 79,872 B, IQ1_S/M 72,704 B with the 16 KB grid). The v1 / pipe launchers forward the types to pipe2. Capability marker slot 580 (`kquant_iq_tile`). qwen35's `kq_mm_pre` and the fused ffn-down / add-norm quantize sites keep an i-quant plane on the tile when the pack carries the slot; only a pack without it still pays the row-major int8 pass.
2. `cuda: dense i-quant dp4a launcher grid overflowed past 134M outputs` - found by the new test at Q3_K token_embd x 1024 rows: the grid was sized in 32 bits and the last 12% of rows were never written. Block-major task index now; the launcher refuses `out_dim * batch` above 2^32.
3. `qwen4exp GGUF lane: dense planes above 64 rows take the W4A8 tile` - `kq_matmul` served every batch above 1 on dp4a; above 64 rows it now quantizes into the mmq tiles and takes pipe2 (the qwen35 prefill rung), chunked at 512 rows off a fixed few-MB scratch on the GGUF lane (row-offset twins of the quantize / tile launchers), so nothing scales with max_ctx. Flash Next's long-prompt prefill is bound elsewhere: the routed experts are read per (token, expert) from host memory over PCIe, and on this box a 400-token prompt prefills in 83 s at 87 slots (6 tokens: 216 ms, decode 24-26 tok/s as in #18), so the dense-plane gain is invisible there. That is the "prefill through the slot cache" item from #18, untouched here and the next thing worth doing for that lane.

Not in this PR: the <= 64-row class (`mma_ks`) still hands i-quant to dp4a - its loader unpacks fragments inline per 4 bytes, which does not fit a 16-weight window unpack without a shuffle exchange; that is the next step if the spec-verify / short-prompt widths want it.

## Verified

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets` - clean on the touched files (the remaining warnings are on `main` untouched)
- [x] `cargo test --workspace` - the GPU suites below on the 5060 Ti (`CUDA_VISIBLE_DEVICES`, as in #9 / #17)
- Built on: Windows 11, VS 2026 with the 14.44 toolset, CUDA 13.0 pack `-Arches 120`
- GPU and driver: RTX 5060 Ti 16 GB, driver 581.80

Gates (`PADDOCK_PACK`, `PADDOCK_HEAVY_TESTS=1`, `--test-threads=1`):

- `iq_w4a8_tile_matches_reference` (new): IQ2_XXS / IQ3_XXS / Q2_K / IQ2_S / IQ3_S planes of Qwen3.5-9B UD-IQ2_XXS at 65 rows vs the raw-bytes CPU dequant (2e-7 .. 5e-7); at 144 and 1024 rows vs the dp4a lane (2e-7 .. 5e-7); Q3_K token_embd at 144 / 1024 rows vs dp4a; the v1 and pipe launchers bit-match pipe2.
- `gpu_qwen35_prefill_vs_serial::batched_prefill_matches_serial_step` on the 9B UD-IQ2_XXS: 16 and 110 tokens pick the serial step's token, 0.0115 / 0.0004 nats on the winner. (The same test on the 9B UD-Q4_K_XL fails its 2e-2 bar on this card at 0.033 nats / 1.4e-1 logits rel_err at 110 tokens, identically on the untouched tree with the pre-PR pack - so the bar is not met by the k-quant lanes here either; I have not chased it.)
- `gguf_kq_dense_tile_matches_dp4a` (new): Flash Next's Q5_K / Q6_K dense planes at 163 rows, tile vs dp4a 2.5e-7 .. 3.7e-7, and the 100-row chunked walk bit-identical to the one-shot tile. `gguf_teacher_forced_agreement` 14/16 unchanged.
- compute-sanitizer memcheck over the tile test on the Q2_K (min-term) and IQ3_XXS planes: 0 errors.
- Serve path (`paddock-runner`, `paddock-bench --endpoint`, 9B UD-IQ2_XXS, a 1461-token prompt): cold TTFT 9117 ms -> 554 ms, same output text, decode 111-113 tok/s either way; four concurrent sessions with distinct 600-word prefixes: TTFT p50 973 ms, 60 tok/s aggregate.
- `iq2_dense_file_serves_at_llama_parity` 22/24 unchanged; the full `gpu_kquant_parity` suite 22 passed (the `nc` lane needs no workaround after bd23391); `attn_partial_batch_paged_bitwise_matches_dense` passes on main now (#5).

Prefill, `prefill_rate_bench` (new, ignored), 2048 tokens, best of three:

| file | before | after |
|---|---|---|
| Qwen3.5-9B UD-IQ2_XXS | 59 tok/s | 1186 tok/s |
| Qwen3.5-9B UD-Q4_K_XL (control) | 1208 | 1208 |
